### PR TITLE
New rule: no-mixed-exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,34 @@ Examples of invalid code
 const myFunction = (parameterA: { foo: string }) => {};
 function myFunction(parameterA: { foo: string }) {}
 ```
+
+### no-mixed-exports
+
+Mixed exports refers to a file having both a default and one or more named exports.
+
+Mixing exports can make the code hard to navigate and unpredictable. This rule forbids mixing exports.
+
+Examples of valid code
+
+```js
+// types.ts
+export type Options = {
+    value: number
+};
+
+// index.ts
+import { Options } from "./types.ts";
+
+export default myFunction(parameters: Options) {...}
+```
+
+Examples of invalid code
+
+```js
+// index.ts
+export type Options = {
+    value: number
+};
+
+export default myFunction(parameters: Options) {...}
+```

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,8 +1,10 @@
 import { noInlineFunctionParameterTypeAnnotation } from "./noInlineFunctionParameterTypeAnnotation";
+import { noMixedExports } from "./noMixedExports";
 
 const rules = {
     "no-inline-function-parameter-type-annotation":
         noInlineFunctionParameterTypeAnnotation,
+    "no-mixed-exports": noMixedExports,
 };
 
 export { rules };

--- a/src/rules/noInlineFunctionParameterTypeAnnotation.ts
+++ b/src/rules/noInlineFunctionParameterTypeAnnotation.ts
@@ -2,19 +2,6 @@ import { AST_NODE_TYPES } from "@typescript-eslint/types";
 import type { Parameter } from "@typescript-eslint/types/dist/generated/ast-spec";
 import { ESLintUtils } from "@typescript-eslint/utils";
 
-function paramsHaveInlineTypeAnnotation(params: Parameter[]) {
-    return params.some((param) => {
-        if (!("typeAnnotation" in param)) {
-            return false;
-        }
-
-        return (
-            param.typeAnnotation?.typeAnnotation.type ===
-            AST_NODE_TYPES.TSTypeLiteral
-        );
-    });
-}
-
 function getParametersWithInlineTypeAnnotations(params: Parameter[]) {
     return params.filter((param) => {
         if (!("typeAnnotation" in param)) {

--- a/src/rules/noMixedExports.ts
+++ b/src/rules/noMixedExports.ts
@@ -1,0 +1,40 @@
+import { ESLintUtils } from "@typescript-eslint/utils";
+
+export const noMixedExports = ESLintUtils.RuleCreator.withoutDocs({
+    create(context) {
+        let hasDefaultExport = false;
+        let hasNamedExport = false;
+
+        return {
+            ExportDefaultDeclaration(node) {
+                hasDefaultExport = true;
+
+                if (hasNamedExport) {
+                    context.report({
+                        node,
+                        messageId: "noMixedExports",
+                    });
+                }
+            },
+            ExportNamedDeclaration(node) {
+                hasNamedExport = true;
+
+                if (hasDefaultExport) {
+                    context.report({
+                        node,
+                        messageId: "noMixedExports",
+                    });
+                }
+            },
+        };
+    },
+    meta: {
+        messages: {
+            noMixedExports:
+                "Do not mix exports, a file should either include named exports or a default export.",
+        },
+        type: "problem",
+        schema: [],
+    },
+    defaultOptions: [],
+});

--- a/src/tests/noMixedExports.test.ts
+++ b/src/tests/noMixedExports.test.ts
@@ -1,0 +1,26 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import * as vitest from "vitest";
+import { noMixedExports } from "../rules/noMixedExports";
+
+RuleTester.afterAll = vitest.afterAll;
+RuleTester.it = vitest.it;
+RuleTester.itOnly = vitest.it.only;
+RuleTester.describe = vitest.describe;
+
+const ruleTester = new RuleTester({
+    parser: "@typescript-eslint/parser",
+});
+
+ruleTester.run("noMixedExports", noMixedExports, {
+    valid: ["export const myExport = () => {}", "export default () => {}"],
+    invalid: [
+        {
+            code: "export const myExport = () => {}; export default () => {}",
+            errors: [
+                {
+                    messageId: "noMixedExports",
+                },
+            ],
+        },
+    ],
+});

--- a/src/tests/noMixedExports.test.ts
+++ b/src/tests/noMixedExports.test.ts
@@ -12,7 +12,11 @@ const ruleTester = new RuleTester({
 });
 
 ruleTester.run("noMixedExports", noMixedExports, {
-    valid: ["export const myExport = () => {}", "export default () => {}"],
+    valid: [
+        "export const myExport = () => {}",
+        "export default () => {}",
+        "export const myExport = () => {}; export const mySecondExport = () => {}; export const myThirdExport = () => {}",
+    ],
     invalid: [
         {
             code: "export const myExport = () => {}; export default () => {}",


### PR DESCRIPTION
This PR adds a new rule "no-mixed-exports"

Mixed exports refers to a file having both a default export and named exports, for example:
```js
export type Options = {
    value: number
}

export default myFunction(parameters: Options) {...}
```

We regularily comment on this in reviews, so to save us time I wrote this small rule which forbids mixing exports