### PR TITLE
Feature/no react namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Writing type annotations inline for function parameters makes the code harder to
 
 Examples of valid code
 
-```js
+```ts
 const myFunction = (parameterA: MyType) => {};
 function myFunction(parameterA: MyType) {}
 const myFunction = (parameterA: string) => {};
@@ -24,7 +24,7 @@ function myFunction(parameterA: string) {}
 
 Examples of invalid code
 
-```js
+```ts
 const myFunction = (parameterA: { foo: string }) => {};
 function myFunction(parameterA: { foo: string }) {}
 ```
@@ -37,7 +37,7 @@ Mixing exports can make the code hard to navigate and unpredictable. This rule f
 
 Examples of valid code
 
-```js
+```ts
 // types.ts
 export type Options = {
     value: number
@@ -51,7 +51,7 @@ export default myFunction(parameters: Options) {...}
 
 Examples of invalid code
 
-```js
+```ts
 // index.ts
 export type Options = {
     value: number
@@ -68,7 +68,7 @@ This rule forbids functions and variables being prefixed with `use` if they do n
 
 Examples of valid code
 
-```js
+```ts
 const useCustom = () => {
     const [state, setState] = useState("");
 
@@ -82,7 +82,7 @@ const useCustom = useState;
 
 Examples of invalid code
 
-```js
+```ts
 const useCustom = () => {
     return "Hello world";
 };
@@ -102,12 +102,12 @@ This rule forbids using the React namespace.
 
 Examples of valid code
 
-```js
+```ts
 const [state, setState] = useState("");
 
 type Props = {
-    children: ReactNode,
-    style: CSSProperties,
+    children: ReactNode;
+    style: CSSProperties;
 };
 
 export default memo(MyComponent);
@@ -115,12 +115,12 @@ export default memo(MyComponent);
 
 Examples of invalid code
 
-```js
+```ts
 const [state, setState] = React.useState("");
 
 type Props = {
-    children: React.ReactNode,
-    style: React.CSSProperties,
+    children: React.ReactNode;
+    style: React.CSSProperties;
 };
 
 export default React.memo(MyComponent);

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ Custom ESLint rules used internally at Meitner
 
 ## Rules
 
+-   [no-inline-function-parameter-type-annotation](#no-inline-function-parameter-type-annotation)
+-   [no-mixed-exports](#no-mixed-exports)
+-   [no-use-prefix-for-non-hook](#no-use-prefix-for-non-hook)
+-   [no-react-namespace](#no-react-namespace)
+
 ### no-inline-function-parameter-type-annotation
 
 Writing type annotations inline for function parameters makes the code harder to read, and introduces inconsistency. This rule forces the developer to write a type or interface.
@@ -85,4 +90,38 @@ const useCustom = () => {
 const useCustom = () => new Date();
 
 const useCustom = new Date();
+```
+
+### no-react-namespace
+
+React functions and types can be either imported individually, or used as a member of the default exported React namespace, mixing these two strategies introduces inconsistency.
+
+It has no real effect on performance or function, but importing functions and types individually makes the code more consistent with modern Javascript packages which tend to not use default export due to tree shaking.
+
+This rule forbids using the React namespace.
+
+Examples of valid code
+
+```js
+const [state, setState] = useState("");
+
+type Props = {
+    children: ReactNode,
+    style: CSSProperties,
+};
+
+export default memo(MyComponent);
+```
+
+Examples of invalid code
+
+```js
+const [state, setState] = React.useState("");
+
+type Props = {
+    children: React.ReactNode,
+    style: React.CSSProperties,
+};
+
+export default React.memo(MyComponent);
 ```

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,5 +1,6 @@
 import { noInlineFunctionParameterTypeAnnotation } from "./noInlineFunctionParameterTypeAnnotation";
 import { noMixedExports } from "./noMixedExports";
+import { noReactNamespace } from "./noReactNamespace";
 import { noUsePrefixForNonHook } from "./noUsePrefixForNonHook";
 
 const rules = {
@@ -7,6 +8,7 @@ const rules = {
         noInlineFunctionParameterTypeAnnotation,
     "no-mixed-exports": noMixedExports,
     "no-use-prefix-for-non-hook": noUsePrefixForNonHook,
+    "no-react-namespace": noReactNamespace,
 };
 
 export { rules };

--- a/src/rules/noReactNamespace.ts
+++ b/src/rules/noReactNamespace.ts
@@ -1,0 +1,41 @@
+import { ESLintUtils } from "@typescript-eslint/utils";
+
+export const noReactNamespace = ESLintUtils.RuleCreator.withoutDocs({
+    create(context) {
+        return {
+            MemberExpression(node) {
+                if (
+                    node.object.type === "Identifier" &&
+                    node.object.name === "React"
+                ) {
+                    context.report({
+                        node,
+                        messageId: "noReactNamespace",
+                    });
+                }
+            },
+            TSTypeAnnotation(node) {
+                if (
+                    node.typeAnnotation.type === "TSTypeReference" &&
+                    node.typeAnnotation.typeName.type === "TSQualifiedName" &&
+                    node.typeAnnotation.typeName.left.type === "Identifier" &&
+                    node.typeAnnotation.typeName.left.name === "React"
+                ) {
+                    context.report({
+                        node,
+                        messageId: "noReactNamespace",
+                    });
+                }
+            },
+        };
+    },
+    meta: {
+        messages: {
+            noReactNamespace:
+                "Do not use the React namespace, import the specific functions or types you need instead.",
+        },
+        type: "problem",
+        schema: [],
+    },
+    defaultOptions: [],
+});

--- a/src/tests/noReactNamespace.test.ts
+++ b/src/tests/noReactNamespace.test.ts
@@ -1,0 +1,37 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import * as vitest from "vitest";
+import { noReactNamespace } from "../rules/noReactNamespace";
+
+RuleTester.afterAll = vitest.afterAll;
+RuleTester.it = vitest.it;
+RuleTester.itOnly = vitest.it.only;
+RuleTester.describe = vitest.describe;
+
+const ruleTester = new RuleTester({
+    parser: "@typescript-eslint/parser",
+});
+
+ruleTester.run("noReactNamespace", noReactNamespace, {
+    valid: [
+        'const [state, setState] = useState("");',
+        "const style: CSSProperties = {};",
+    ],
+    invalid: [
+        {
+            code: "const [state, setState] = React.useState('');",
+            errors: [
+                {
+                    messageId: "noReactNamespace",
+                },
+            ],
+        },
+        {
+            code: "const style: React.CSSProperties = {};",
+            errors: [
+                {
+                    messageId: "noReactNamespace",
+                },
+            ],
+        },
+    ],
+});


### PR DESCRIPTION
This PR adds a new rule "no-react-namespace"

It forbids using functions and types on the React namespace, such as 
```ts
const [state, setState] = React.useState("");

type Props = {
    children: React.ReactNode,
    style: React.CSSProperties,
};

export default React.memo(MyComponent);
```