### PR TITLE
[no-use-prefix-for-non-hook]: Fix allow call expression assignment

### DIFF
--- a/src/rules/noUsePrefixForNonHook.ts
+++ b/src/rules/noUsePrefixForNonHook.ts
@@ -176,6 +176,14 @@ export const noUsePrefixForNonHook = ESLintUtils.RuleCreator.withoutDocs({
                     return;
                 }
 
+                // Check if the variable is assigned a function, we accept functions named as hooks or not, since it's quite common to create a hook with a factory function, such as `createStore` from `zustand`
+                if (
+                    declaration.init &&
+                    declaration.init.type === "CallExpression"
+                ) {
+                    return;
+                }
+
                 context.report({
                     node,
                     messageId: "noUsePrefixForNonHook",

--- a/src/tests/noUsePrefixForNonHook.test.ts
+++ b/src/tests/noUsePrefixForNonHook.test.ts
@@ -31,6 +31,7 @@ ruleTester.run("noUsePrefixForNonHook", noUsePrefixForNonHook, {
         "const user = null;",
         "const myVariable = null;",
         "const data = useUserData();",
+        "const useStore = createStore();",
     ],
     invalid: [
         {


### PR DESCRIPTION
This PR makes an adjustment to the no-use-prefix-for-non-hook rule.

I noticed when running this rule on the codebase that it warns on store hooks created by zustand,
they look like this:
```
const useUserStore = create(...);
```

To solve this I opted towards just allowing all function call expressions to be assigned to a variable with the `use` prefix. In the future we could possibly add a configuration option where you can send in a regex or something