### PR TITLE
Feature/no literal jsx style prop values

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Custom ESLint rules used internally at Meitner
 -   [no-mixed-exports](#no-mixed-exports)
 -   [no-use-prefix-for-non-hook](#no-use-prefix-for-non-hook)
 -   [no-react-namespace](#no-react-namespace)
+-   [no-literal-jsx-style-prop-values](#no-literal-jsx-style-prop-values)
 
 ### no-inline-function-parameter-type-annotation
 
@@ -124,4 +125,32 @@ type Props = {
 };
 
 export default React.memo(MyComponent);
+```
+
+### no-literal-jsx-style-prop-values
+
+Styles should be written in real CSS and applied to elements with `className`, this means less JS code, faster build time, faster load time, better UX and better DX
+
+Often styles will need to be changed based on various conditions, most of the time we can just apply different classNames, but sometimes we need to set styles to dynamic JS values
+
+This rule forbids using literal values in the JSX style prop.
+
+Examples of valid code
+
+```ts
+<div style={{ color: myMagicColor }} />
+
+<div style={{ gap: myMagicGap * size }}>
+
+<div style={{ border: `1px solid ${getMagicColor()}` }} />
+```
+
+Examples of invalid code
+
+```ts
+<div style={{ color: "red" }} />
+
+<div style={{ color: isMagic ? "red" : "blue" }}>
+
+<div style={{ border: `1px solid ${isMagic ? "red" : "blue"}` }} />
 ```

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,4 +1,5 @@
 import { noInlineFunctionParameterTypeAnnotation } from "./noInlineFunctionParameterTypeAnnotation";
+import { noLiteralJSXStylePropValues } from "./noLiteralJSXStylePropValues";
 import { noMixedExports } from "./noMixedExports";
 import { noReactNamespace } from "./noReactNamespace";
 import { noUsePrefixForNonHook } from "./noUsePrefixForNonHook";
@@ -9,6 +10,7 @@ const rules = {
     "no-mixed-exports": noMixedExports,
     "no-use-prefix-for-non-hook": noUsePrefixForNonHook,
     "no-react-namespace": noReactNamespace,
+    "no-literal-jsx-style-prop-values": noLiteralJSXStylePropValues,
 };
 
 export { rules };

--- a/src/rules/noLiteralJSXStylePropValues.ts
+++ b/src/rules/noLiteralJSXStylePropValues.ts
@@ -1,0 +1,132 @@
+import {
+    ConditionalExpression,
+    ObjectLiteralElement,
+    TemplateLiteral,
+} from "@typescript-eslint/types/dist/generated/ast-spec";
+import { ESLintUtils } from "@typescript-eslint/utils";
+
+function isConditionalExpressionValid(expression: ConditionalExpression) {
+    // If the consequent value of a conditional expression is a literal we should report it. Consequent means the value that is returned if the condition is true.
+    if (expression.consequent.type === "Literal") {
+        return false;
+    }
+
+    // If the alternate value of a conditional expression is a literal we should report it. Alternate means the value that is returned if the condition is false.
+    if (expression.alternate.type === "Literal") {
+        return false;
+    }
+
+    return true;
+}
+
+function isTemplateLiteralValid(literal: TemplateLiteral) {
+    const expressions = literal.expressions;
+
+    if (expressions.length === 0) {
+        return false;
+    }
+
+    const literalExpressions = literal.expressions.filter(
+        (expression) => expression.type === "Literal"
+    );
+
+    if (literalExpressions.length > 0) {
+        return false;
+    }
+
+    const hasInvalidConditionalExpressions = expressions.some(
+        (expression) =>
+            expression.type === "ConditionalExpression" &&
+            !isConditionalExpressionValid(expression)
+    );
+
+    if (hasInvalidConditionalExpressions) {
+        return false;
+    }
+
+    return true;
+}
+
+function isExpressionPropertyValid(property: ObjectLiteralElement) {
+    if (property.type !== "Property") {
+        return false;
+    }
+
+    // If the value is a literal, it's static and we should report it.
+    if (property.value.type === "Literal") {
+        return false;
+    }
+
+    // If the value is a conditional expression, we need to check if it's valid
+    if (
+        property.value.type === "ConditionalExpression" &&
+        !isConditionalExpressionValid(property.value)
+    ) {
+        return false;
+    }
+
+    if (
+        property.value.type === "TemplateLiteral" &&
+        !isTemplateLiteralValid(property.value)
+    ) {
+        return false;
+    }
+
+    return true;
+}
+
+export const noLiteralJSXStylePropValues = ESLintUtils.RuleCreator.withoutDocs({
+    create(context) {
+        return {
+            JSXElement(node) {
+                const styleAttribute = node.openingElement.attributes.find(
+                    (attribute) =>
+                        attribute.type === "JSXAttribute" &&
+                        attribute.name.name === "style"
+                );
+
+                if (
+                    styleAttribute === undefined ||
+                    styleAttribute.type !== "JSXAttribute"
+                ) {
+                    return;
+                }
+
+                const value = styleAttribute.value;
+
+                if (value === null || value.type !== "JSXExpressionContainer") {
+                    return;
+                }
+
+                const expression = value.expression;
+
+                if (expression.type !== "ObjectExpression") {
+                    return;
+                }
+
+                const arePropertiesValid = expression.properties.every(
+                    isExpressionPropertyValid
+                );
+
+                if (arePropertiesValid) {
+                    return;
+                }
+
+                context.report({
+                    node,
+                    messageId: "noLiteralJSXStylePropValues",
+                    loc: styleAttribute.loc,
+                });
+            },
+        };
+    },
+    meta: {
+        messages: {
+            noLiteralJSXStylePropValues:
+                "Do not use literal values in JSX style props.",
+        },
+        type: "problem",
+        schema: [],
+    },
+    defaultOptions: [],
+});

--- a/src/tests/noLiteralJSXStylePropValues.test.ts
+++ b/src/tests/noLiteralJSXStylePropValues.test.ts
@@ -1,0 +1,131 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import * as vitest from "vitest";
+import { noLiteralJSXStylePropValues } from "../rules/noLiteralJSXStylePropValues";
+
+RuleTester.afterAll = vitest.afterAll;
+RuleTester.it = vitest.it;
+RuleTester.itOnly = vitest.it.only;
+RuleTester.describe = vitest.describe;
+
+const ruleTester = new RuleTester({
+    parser: "@typescript-eslint/parser",
+});
+
+ruleTester.run("noLiteralJSXStylePropValues", noLiteralJSXStylePropValues, {
+    valid: [
+        {
+            code: "<div />",
+            parserOptions: { ecmaFeatures: { jsx: true } },
+        },
+        {
+            code: "<div style={myMagicStyle} />",
+            parserOptions: { ecmaFeatures: { jsx: true } },
+        },
+        {
+            code: "<div style={{ color: myMagicColor }} />",
+            parserOptions: { ecmaFeatures: { jsx: true } },
+        },
+        {
+            code: "<div style={{ color: myMagicColor, backgroundColor: myMagicBackgroundColor }} />",
+            parserOptions: { ecmaFeatures: { jsx: true } },
+        },
+        {
+            code: "<div style={{ gap: myMagicGap * size }} />",
+            parserOptions: { ecmaFeatures: { jsx: true } },
+        },
+        {
+            code: "<div style={{ gap: getMagicColor() }} />",
+            parserOptions: { ecmaFeatures: { jsx: true } },
+        },
+        {
+            code: "<div style={{ gap: isMagic ? getMagicColor() : undefined }} />",
+            parserOptions: { ecmaFeatures: { jsx: true } },
+        },
+        {
+            code: "<div style={{ border: `1px solid ${myMagicBorderColor}` }} />",
+            parserOptions: { ecmaFeatures: { jsx: true } },
+        },
+        {
+            code: "<div style={{ border: `1px solid ${getMagicBorderColor()}` }} />",
+            parserOptions: { ecmaFeatures: { jsx: true } },
+        },
+        {
+            code: "<div style={{ border: `1px solid ${isMagic ? getMagicColor() : getNormalColor()}` }} />",
+            parserOptions: { ecmaFeatures: { jsx: true } },
+        },
+    ],
+    invalid: [
+        {
+            code: '<div style={{ color: "red" }} />',
+            parserOptions: { ecmaFeatures: { jsx: true } },
+            errors: [
+                {
+                    messageId: "noLiteralJSXStylePropValues",
+                },
+            ],
+        },
+        {
+            code: '<div style={{ color: myMagicColor, backgroundColor: "white" }} />',
+            parserOptions: { ecmaFeatures: { jsx: true } },
+            errors: [
+                {
+                    messageId: "noLiteralJSXStylePropValues",
+                },
+            ],
+        },
+        {
+            code: '<div style={{ color: isMagic ? "red" : "blue" }} />',
+            parserOptions: { ecmaFeatures: { jsx: true } },
+            errors: [
+                {
+                    messageId: "noLiteralJSXStylePropValues",
+                },
+            ],
+        },
+        {
+            code: '<div style={{ color: isMagic ? getMagicColor() : "blue" }} />',
+            parserOptions: { ecmaFeatures: { jsx: true } },
+            errors: [
+                {
+                    messageId: "noLiteralJSXStylePropValues",
+                },
+            ],
+        },
+        {
+            code: '<div style={{ border: `1px solid ${isMagic ? "red" : "blue"}` }} />',
+            parserOptions: { ecmaFeatures: { jsx: true } },
+            errors: [
+                {
+                    messageId: "noLiteralJSXStylePropValues",
+                },
+            ],
+        },
+        {
+            code: '<div style={{ border: `1px solid ${isMagic ? myMagicBorderColor : "blue"}` }} />',
+            parserOptions: { ecmaFeatures: { jsx: true } },
+            errors: [
+                {
+                    messageId: "noLiteralJSXStylePropValues",
+                },
+            ],
+        },
+        {
+            code: "<div style={{ border: `1px solid blue` }} />",
+            parserOptions: { ecmaFeatures: { jsx: true } },
+            errors: [
+                {
+                    messageId: "noLiteralJSXStylePropValues",
+                },
+            ],
+        },
+        {
+            code: '<div style={{ border: `1px solid ${"blue"}` }} />',
+            parserOptions: { ecmaFeatures: { jsx: true } },
+            errors: [
+                {
+                    messageId: "noLiteralJSXStylePropValues",
+                },
+            ],
+        },
+    ],
+});


### PR DESCRIPTION
This PR adds a new rule: no-literal-jsx-style-prop-values

We prefer writing styles in CSS and applying them with classNames, but sometimes we need to use the style prop to apply dynamic styles, this rule warns against literal values in the style prop