### PR TITLE
New rule: always-spread-jsx-props-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,3 +154,25 @@ Examples of invalid code
 
 <div style={{ border: `1px solid ${isMagic ? "red" : "blue"}` }} />
 ```
+
+### always-spread-jsx-props-first
+
+Spreading props can is a common pattern in React, but it can also lead to unintended behavior if not used carefully.
+
+This rule forces JSX spread props to always be the first prop in the list.
+
+Examples of valid code
+
+```ts
+<Component {...props} myProp={myValue} />
+
+<Component {...props} />
+
+<Component />
+```
+
+Examples of invalid code
+
+```ts
+<Component myProp={myValue} {...props} />
+```

--- a/README.md
+++ b/README.md
@@ -157,7 +157,9 @@ Examples of invalid code
 
 ### always-spread-jsx-props-first
 
-Spreading props can is a common pattern in React, but it can also lead to unintended behavior if not used carefully.
+Spreading props is a common pattern in React, but it can also lead to unintended behavior if not used carefully.
+
+By putting the spread props first, we can avoid unintended behavior, such as overriding props with the same name.
 
 This rule forces JSX spread props to always be the first prop in the list.
 

--- a/src/rules/alwaysSpreadJSXPropsFirst.ts
+++ b/src/rules/alwaysSpreadJSXPropsFirst.ts
@@ -1,0 +1,45 @@
+import { ESLintUtils } from "@typescript-eslint/utils";
+
+export const alwaysSpreadJSXPropsFirst = ESLintUtils.RuleCreator.withoutDocs({
+    create(context) {
+        return {
+            JSXOpeningElement(node) {
+                const attributes = node.attributes;
+
+                if (attributes.length === 0) {
+                    return;
+                }
+
+                const hasSpreadAttribute = attributes.some(
+                    (attribute) => attribute.type === "JSXSpreadAttribute"
+                );
+
+                if (!hasSpreadAttribute) {
+                    return;
+                }
+
+                const spreadAttributeIndex = attributes.findIndex(
+                    (attribute) => attribute.type === "JSXSpreadAttribute"
+                );
+
+                if (spreadAttributeIndex === 0) {
+                    return;
+                }
+
+                context.report({
+                    node,
+                    messageId: "alwaysSpreadJSXPropsFirst",
+                });
+            },
+        };
+    },
+    meta: {
+        messages: {
+            alwaysSpreadJSXPropsFirst:
+                "Always put JSX spread props first to avoid unintended behavior",
+        },
+        type: "problem",
+        schema: [],
+    },
+    defaultOptions: [],
+});

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,3 +1,4 @@
+import { alwaysSpreadJSXPropsFirst } from "./alwaysSpreadJSXPropsFirst";
 import { noInlineFunctionParameterTypeAnnotation } from "./noInlineFunctionParameterTypeAnnotation";
 import { noLiteralJSXStylePropValues } from "./noLiteralJSXStylePropValues";
 import { noMixedExports } from "./noMixedExports";
@@ -11,6 +12,7 @@ const rules = {
     "no-use-prefix-for-non-hook": noUsePrefixForNonHook,
     "no-react-namespace": noReactNamespace,
     "no-literal-jsx-style-prop-values": noLiteralJSXStylePropValues,
+    "always-spread-props-first": alwaysSpreadJSXPropsFirst,
 };
 
 export { rules };

--- a/src/tests/alwaysSpreadPropsFirst.test.ts
+++ b/src/tests/alwaysSpreadPropsFirst.test.ts
@@ -1,0 +1,44 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import * as vitest from "vitest";
+import { alwaysSpreadJSXPropsFirst } from "../rules/alwaysSpreadJSXPropsFirst";
+
+RuleTester.afterAll = vitest.afterAll;
+RuleTester.it = vitest.it;
+RuleTester.itOnly = vitest.it.only;
+RuleTester.describe = vitest.describe;
+
+const ruleTester = new RuleTester({
+    parser: "@typescript-eslint/parser",
+});
+
+ruleTester.run("alwaysSpreadJSXPropsFirst", alwaysSpreadJSXPropsFirst, {
+    valid: [
+        {
+            code: "<Component {...props} myProp={myValue} />",
+            parserOptions: { ecmaFeatures: { jsx: true } },
+        },
+        {
+            code: "<Component {...props} />",
+            parserOptions: { ecmaFeatures: { jsx: true } },
+        },
+        {
+            code: "<Component myProp={myValue} />",
+            parserOptions: { ecmaFeatures: { jsx: true } },
+        },
+        {
+            code: "<Component />",
+            parserOptions: { ecmaFeatures: { jsx: true } },
+        },
+    ],
+    invalid: [
+        {
+            code: "<Component myProp={myValue} {...props} />",
+            parserOptions: { ecmaFeatures: { jsx: true } },
+            errors: [
+                {
+                    messageId: "alwaysSpreadJSXPropsFirst",
+                },
+            ],
+        },
+    ],
+});


### PR DESCRIPTION
This PR adds a new rule "always-spread-jsx-props-first"

The reason for putting the spread first is to avoid accidentally overriding explicitly set props

Thanks to @dennis-meitner for the idea