### PR TITLE
Update alwaysSpreadJSXPropsFirst to allow key before spread

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,11 +162,13 @@ Spreading props is a common pattern in React, but it can also lead to unintended
 
 By putting the spread props first, we can avoid unintended behavior, such as overriding props with the same name.
 
-This rule forces JSX spread props to always be the first prop in the list.
+This rule forces JSX spread props to always be the first prop in the list, and to only allow the `key` prop before the spread props.
 
 Examples of valid code
 
 ```ts
+<Component key={myKey} {...props} myProp={myValue} />
+
 <Component {...props} myProp={myValue} />
 
 <Component {...props} />

--- a/src/rules/alwaysSpreadJSXPropsFirst.ts
+++ b/src/rules/alwaysSpreadJSXPropsFirst.ts
@@ -26,17 +26,27 @@ export const alwaysSpreadJSXPropsFirst = ESLintUtils.RuleCreator.withoutDocs({
                     return;
                 }
 
-                context.report({
-                    node,
-                    messageId: "alwaysSpreadJSXPropsFirst",
-                });
+                const beforeSpread = attributes.slice(0, spreadAttributeIndex);
+
+                const hasOnlyKeyBeforeSpread = beforeSpread.every(
+                    (attribute) =>
+                        attribute.type === "JSXAttribute" &&
+                        attribute.name.name === "key"
+                );
+
+                if (!hasOnlyKeyBeforeSpread) {
+                    context.report({
+                        node,
+                        messageId: "alwaysSpreadJSXPropsFirst",
+                    });
+                }
             },
         };
     },
     meta: {
         messages: {
             alwaysSpreadJSXPropsFirst:
-                "Always put JSX spread props first to avoid unintended behavior",
+                "Only 'key' prop is allowed before JSX spread props.",
         },
         type: "problem",
         schema: [],

--- a/src/tests/alwaysSpreadPropsFirst.test.ts
+++ b/src/tests/alwaysSpreadPropsFirst.test.ts
@@ -14,6 +14,10 @@ const ruleTester = new RuleTester({
 ruleTester.run("alwaysSpreadJSXPropsFirst", alwaysSpreadJSXPropsFirst, {
     valid: [
         {
+            code: "<Component key={key} {...props} myProp={myValue} />",
+            parserOptions: { ecmaFeatures: { jsx: true } },
+        },
+        {
             code: "<Component {...props} myProp={myValue} />",
             parserOptions: { ecmaFeatures: { jsx: true } },
         },


### PR DESCRIPTION
This adds support to allow a `key` prop to be placed before a JSX spread.

New valid scenario:
```
        {
            code: "<Component key={key} {...props} myProp={myValue} />",
            parserOptions: { ecmaFeatures: { jsx: true } },
        },
```