### PR TITLE
Fix spread in style prop

### DIFF
--- a/src/rules/noLiteralJSXStylePropValues.ts
+++ b/src/rules/noLiteralJSXStylePropValues.ts
@@ -48,6 +48,10 @@ function isTemplateLiteralValid(literal: TemplateLiteral) {
 }
 
 function isExpressionPropertyValid(property: ObjectLiteralElement) {
+    if (property.type === "SpreadElement") {
+        return true;
+    }
+
     if (property.type !== "Property") {
         return false;
     }

--- a/src/tests/noLiteralJSXStylePropValues.test.ts
+++ b/src/tests/noLiteralJSXStylePropValues.test.ts
@@ -53,6 +53,10 @@ ruleTester.run("noLiteralJSXStylePropValues", noLiteralJSXStylePropValues, {
             code: "<div style={{ border: `1px solid ${isMagic ? getMagicColor() : getNormalColor()}` }} />",
             parserOptions: { ecmaFeatures: { jsx: true } },
         },
+        {
+            code: "<div style={{ ...getMagicStyles() }} />",
+            parserOptions: { ecmaFeatures: { jsx: true } },
+        },
     ],
     invalid: [
         {


### PR DESCRIPTION
This PR fixes a bug where spreading styles in the `style` prop wasn't considered valid by the `no-literal-jsx-style-prop-values`