### PR TITLE
preferTernaryForJSXExpressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,49 @@ Custom ESLint rules used internally at Meitner
 
 ## Rules
 
+-   [prefer-ternary-for-jsx-expressions](#prefer-ternary-for-jsx-expressions)
 -   [no-inline-function-parameter-type-annotation](#no-inline-function-parameter-type-annotation)
 -   [no-mixed-exports](#no-mixed-exports)
 -   [no-use-prefix-for-non-hook](#no-use-prefix-for-non-hook)
 -   [no-react-namespace](#no-react-namespace)
 -   [no-literal-jsx-style-prop-values](#no-literal-jsx-style-prop-values)
 -   [no-exported-types-outside-types-file](#no-exported-types-outside-types-file)
+
+### prefer-ternary-for-jsx-expressions
+
+Using the logical AND operator (`&&`) for conditional rendering in JSX can lead to unintended rendering of falsy values like `0`. This rule encourages using ternary expressions instead, which explicitly handle the falsy case.
+
+Examples of valid code
+
+```tsx
+{
+    condition ? <Component /> : null;
+}
+
+{
+    isLoading ? <Spinner /> : null;
+}
+
+{
+    items.length ? renderItems() : null;
+}
+```
+
+Examples of invalid code
+
+```tsx
+{
+    condition && <Component />;
+}
+
+{
+    isLoading && <Spinner />;
+}
+
+{
+    items.length && renderItems();
+}
+```
 
 ### no-inline-function-parameter-type-annotation
 

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -5,6 +5,7 @@ import { noLiteralJSXStylePropValues } from "./noLiteralJSXStylePropValues";
 import { noMixedExports } from "./noMixedExports";
 import { noReactNamespace } from "./noReactNamespace";
 import { noUsePrefixForNonHook } from "./noUsePrefixForNonHook";
+import { preferTernaryForJSXExpressions } from "./preferTernaryForJSXExpressions";
 
 const rules = {
     "no-inline-function-parameter-type-annotation":
@@ -15,6 +16,7 @@ const rules = {
     "no-literal-jsx-style-prop-values": noLiteralJSXStylePropValues,
     "always-spread-props-first": alwaysSpreadJSXPropsFirst,
     "no-exported-types-in-tsx-files": noExportedTypesInTsxFiles,
+    "prefer-ternary-for-jsx-expressions": preferTernaryForJSXExpressions,
 };
 
 export { rules };

--- a/src/rules/preferTernaryForJSXExpressions.ts
+++ b/src/rules/preferTernaryForJSXExpressions.ts
@@ -1,0 +1,43 @@
+import { ESLintUtils } from "@typescript-eslint/utils";
+
+export const preferTernaryForJSXExpressions =
+    ESLintUtils.RuleCreator.withoutDocs({
+        create(context) {
+            return {
+                LogicalExpression(node) {
+                    // Only target logical AND expressions with JSX on the right side of the operator
+                    const isJSXElement =
+                        node.operator === "&&" &&
+                        (node.right.type === "JSXElement" ||
+                            node.right.type === "JSXFragment" ||
+                            (node.right.type === "CallExpression" &&
+                                node.right.callee.type === "Identifier" &&
+                                /^render[A-Z]/.test(node.right.callee.name)));
+
+                    if (isJSXElement) {
+                        context.report({
+                            node,
+                            messageId: "preferTernaryForJSXExpressions",
+                            fix: (fixer) => {
+                                // Replace "condition && component" with "condition ? component : null" with shortcut in your editor
+                                return fixer.replaceText(
+                                    node,
+                                    `${context.sourceCode.getText(node.left)} ? ${context.sourceCode.getText(node.right)} : null`
+                                );
+                            },
+                        });
+                    }
+                },
+            };
+        },
+        meta: {
+            messages: {
+                preferTernaryForJSXExpressions:
+                    "Prefer ternary operator over '&&' for conditional rendering",
+            },
+            type: "suggestion",
+            schema: [],
+            fixable: "code",
+        },
+        defaultOptions: [],
+    });

--- a/src/tests/preferTernaryForJSXExpressions.test.ts
+++ b/src/tests/preferTernaryForJSXExpressions.test.ts
@@ -1,0 +1,71 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import * as vitest from "vitest";
+import { preferTernaryForJSXExpressions } from "../rules/preferTernaryForJSXExpressions";
+
+RuleTester.afterAll = vitest.afterAll;
+RuleTester.it = vitest.it;
+RuleTester.itOnly = vitest.it.only;
+RuleTester.describe = vitest.describe;
+
+const ruleTester = new RuleTester({
+    parser: "@typescript-eslint/parser",
+});
+
+ruleTester.run(
+    "preferTernaryForJSXExpressions",
+    preferTernaryForJSXExpressions,
+    {
+        valid: [
+            {
+                code: "myValue ? <Component /> : null",
+                parserOptions: { ecmaFeatures: { jsx: true } },
+            },
+            {
+                code: "myValue ? <>My Component Yo</> : null",
+                parserOptions: { ecmaFeatures: { jsx: true } },
+            },
+            {
+                code: "myValue ? <>My Content Yo</> : null",
+                parserOptions: { ecmaFeatures: { jsx: true } },
+            },
+            {
+                code: "myValue ? renderMyComponent() : null",
+                parserOptions: { ecmaFeatures: { jsx: true } },
+            },
+            {
+                code: "myValue && myMagicValue ? renderMyComponent() : null",
+                parserOptions: { ecmaFeatures: { jsx: true } },
+            },
+            {
+                code: "<Component />",
+                parserOptions: { ecmaFeatures: { jsx: true } },
+            },
+            {
+                code: "renderMyComponent()",
+                parserOptions: { ecmaFeatures: { jsx: true } },
+            },
+        ],
+        invalid: [
+            {
+                code: "myValue && <Component />",
+                parserOptions: { ecmaFeatures: { jsx: true } },
+                errors: [
+                    {
+                        messageId: "preferTernaryForJSXExpressions",
+                    },
+                ],
+                output: "myValue ? <Component /> : null",
+            },
+            {
+                code: "myValue && renderMyComponent()",
+                parserOptions: { ecmaFeatures: { jsx: true } },
+                errors: [
+                    {
+                        messageId: "preferTernaryForJSXExpressions",
+                    },
+                ],
+                output: "myValue ? renderMyComponent() : null",
+            },
+        ],
+    }
+);

--- a/src/tests/preferTernaryForJSXExpressions.test.ts
+++ b/src/tests/preferTernaryForJSXExpressions.test.ts
@@ -21,15 +21,23 @@ ruleTester.run(
                 parserOptions: { ecmaFeatures: { jsx: true } },
             },
             {
+                code: "myValue ? null : <Component />",
+                parserOptions: { ecmaFeatures: { jsx: true } },
+            },
+            {
                 code: "myValue ? <>My Component Yo</> : null",
                 parserOptions: { ecmaFeatures: { jsx: true } },
             },
             {
-                code: "myValue ? <>My Content Yo</> : null",
+                code: "myValue ? null : <>My Content Yo</>",
                 parserOptions: { ecmaFeatures: { jsx: true } },
             },
             {
                 code: "myValue ? renderMyComponent() : null",
+                parserOptions: { ecmaFeatures: { jsx: true } },
+            },
+            {
+                code: "myValue ? null : renderMyComponent()",
                 parserOptions: { ecmaFeatures: { jsx: true } },
             },
             {


### PR DESCRIPTION
Using the logical AND operator (`&&`) for conditional rendering in JSX can lead to unintended rendering of falsy values like `0`. This rule encourages using ternary expressions instead, which explicitly handle the falsy case.

Examples of valid code

```tsx
{
    condition ? <Component /> : null;
}

{
    isLoading ? <Spinner /> : null;
}

{
    items.length ? renderItems() : null;
}
```

Examples of invalid code

```tsx
{
    condition && <Component />;
}

{
    isLoading && <Spinner />;
}

{
    items.length && renderItems();
}
```