### PR TITLE
Update alwaysUppercaseID rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
         "type": "git",
         "url": "git+https://github.com/meitner-se/eslint-plugin.git"
     },
-    "version": "1.5.6",
+    "version": "1.6.0",
     "main": "dist/src/index.js",
     "sideEffects": false,
     "keywords": [

--- a/src/rules/alwaysUppercaseID.ts
+++ b/src/rules/alwaysUppercaseID.ts
@@ -4,6 +4,15 @@ export const alwaysUppercaseID = ESLintUtils.RuleCreator.withoutDocs({
     create(context) {
         return {
             Identifier(node) {
+                // Skip identifiers in import statements
+                if (
+                    node.parent?.type === "ImportSpecifier" ||
+                    node.parent?.type === "ImportDefaultSpecifier" ||
+                    node.parent?.type === "ImportNamespaceSpecifier"
+                ) {
+                    return;
+                }
+
                 const name = node.name;
 
                 // Match "Ids" that are not part of "IDs" so we can catch multiple matches in a single string, eg. userIDsMappedByGroupIds

--- a/src/tests/alwaysUppercaseID.test.ts
+++ b/src/tests/alwaysUppercaseID.test.ts
@@ -24,6 +24,14 @@ ruleTester.run("alwaysUppercaseID", alwaysUppercaseID, {
         "const identity = x => x;",
         "const userIDsMappedByGroupIDs = 123;",
         "const userIDMappedByGroupIDs = 123;",
+
+        // Import statements should be ignored
+        "import { myMagicalId } from 'module';",
+        "import { myMagicalIds } from 'module';",
+        "import myMagicalId from 'module';",
+        "import myMagicalIds from 'module';",
+        "import * as myMagicalId from 'module';",
+        "import * as myMagicalIds from 'module';",
     ],
     invalid: [
         {


### PR DESCRIPTION
This updates the alwaysUppercaseID rule to not trigger on import statements.

These are now invalid:
```
// Import statements should be ignored
"import { myMagicalId } from 'module';",
"import { myMagicalIds } from 'module';",
"import myMagicalId from 'module';",
"import myMagicalIds from 'module';",
"import * as myMagicalId from 'module';",
"import * as myMagicalIds from 'module';",
```