### PR TITLE
Support React 19 use()

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Custom ESLint rules used internally at Meitner
 -   [no-exported-types-outside-types-file](#no-exported-types-outside-types-file)
 -   [always-spread-jsx-props-first](#always-spread-jsx-props-first)
 -   [no-exported-types-in-tsx-files](#no-exported-types-in-tsx-files)
--   [always-capitalize-id](#always-capitalize-id)
 
 ### prefer-ternary-for-jsx-expressions
 
@@ -243,13 +242,11 @@ Examples of invalid code
 
 ```ts
 // MyComponent.tsx
-import { Props } from "./MyComponent.types";
+export type Props = {
+    children: ReactNode;
+};
 
 export default function MyComponent(props: Props) { // error
     return <div>{props.children}</div>;
 }
-
-export type Props = {
-    children: ReactNode;
-};
 ```

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
         "type": "git",
         "url": "git+https://github.com/meitner-se/eslint-plugin.git"
     },
-    "version": "1.6.0",
+    "version": "1.7.0",
     "main": "dist/src/index.js",
     "sideEffects": false,
     "keywords": [

--- a/src/rules/noUsePrefixForNonHook.ts
+++ b/src/rules/noUsePrefixForNonHook.ts
@@ -5,7 +5,7 @@ import {
 } from "@typescript-eslint/types/dist/generated/ast-spec";
 import { ESLintUtils } from "@typescript-eslint/utils";
 
-const PREFIX_REGEX = /^use[A-Z]/;
+const PREFIX_REGEX = /^use($|[A-Z])/;
 
 function hasUsePrefix(name: string) {
     return name.match(PREFIX_REGEX) !== null;

--- a/src/tests/noUsePrefixForNonHook.test.ts
+++ b/src/tests/noUsePrefixForNonHook.test.ts
@@ -32,6 +32,7 @@ ruleTester.run("noUsePrefixForNonHook", noUsePrefixForNonHook, {
         "const myVariable = null;",
         "const data = useUserData();",
         "const useStore = createStore();",
+        "const useMagic = () => {return use(MagicContext)}",
     ],
     invalid: [
         {


### PR DESCRIPTION
This PR adds support for the React 19 use() API on the no-use-prefix-for-non-hook rule.

I also made some small tweaks to the README