### PR TITLE
Add css-module-import-name rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Custom ESLint rules used internally at Meitner
 -   [no-exported-types-outside-types-file](#no-exported-types-outside-types-file)
 -   [always-spread-jsx-props-first](#always-spread-jsx-props-first)
 -   [no-exported-types-in-tsx-files](#no-exported-types-in-tsx-files)
+-   [css-module-import-name](#css-module-import-name)
 
 ### prefer-ternary-for-jsx-expressions
 
@@ -249,4 +250,36 @@ export type Props = {
 export default function MyComponent(props: Props) { // error
     return <div>{props.children}</div>;
 }
+```
+
+### css-module-import-name
+
+CSS module imports should use a consistent name across the codebase. By default, this rule enforces the name `classes`, but it can be configured to any name.
+
+This rule is auto-fixable.
+
+Configuration
+
+```json
+// Use default name "classes"
+"@meitner/css-module-import-name": "error"
+
+// Use custom name
+"@meitner/css-module-import-name": ["error", { "name": "styles" }]
+```
+
+Examples of valid code
+
+```ts
+import classes from "./styles.module.css";
+import classes from "./styles.module.scss";
+import classes from "./styles.module.less";
+```
+
+Examples of invalid code
+
+```ts
+import styles from "./styles.module.css";
+import css from "./styles.module.scss";
+import s from "./styles.module.less";
 ```

--- a/src/rules/cssModuleImportName.ts
+++ b/src/rules/cssModuleImportName.ts
@@ -1,0 +1,75 @@
+import { ESLintUtils } from "@typescript-eslint/utils";
+
+const CSS_MODULE_EXTENSIONS = [".module.css", ".module.scss", ".module.less"];
+
+function isCSSModuleImport(source: string): boolean {
+    return CSS_MODULE_EXTENSIONS.some((ext) => source.endsWith(ext));
+}
+
+type Options = [{ name: string }];
+
+export const cssModuleImportName = ESLintUtils.RuleCreator.withoutDocs<
+    Options,
+    "cssModuleImportName"
+>({
+    create(context, [options]) {
+        const expectedName = options.name;
+
+        return {
+            ImportDeclaration(node) {
+                const source = node.source.value;
+
+                if (typeof source !== "string" || !isCSSModuleImport(source)) {
+                    return;
+                }
+
+                if (node.specifiers.length !== 1) {
+                    return;
+                }
+
+                const specifier = node.specifiers[0];
+
+                if (specifier.type !== "ImportDefaultSpecifier") {
+                    return;
+                }
+
+                if (specifier.local.name !== expectedName) {
+                    context.report({
+                        node: specifier,
+                        messageId: "cssModuleImportName",
+                        data: {
+                            expected: expectedName,
+                            actual: specifier.local.name,
+                        },
+                        fix(fixer) {
+                            return fixer.replaceText(
+                                specifier.local,
+                                expectedName,
+                            );
+                        },
+                    });
+                }
+            },
+        };
+    },
+    meta: {
+        messages: {
+            cssModuleImportName:
+                'CSS module imports should be named "{{ expected }}", found "{{ actual }}".',
+        },
+        type: "suggestion",
+        fixable: "code",
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    name: {
+                        type: "string",
+                    },
+                },
+                additionalProperties: false,
+            },
+        ],
+    },
+    defaultOptions: [{ name: "classes" }],
+});

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,4 +1,5 @@
 import { alwaysSpreadJSXPropsFirst } from "./alwaysSpreadJSXPropsFirst";
+import { cssModuleImportName } from "./cssModuleImportName";
 import { noExportedTypesInTsxFiles } from "./noExportedTypesInTsxFiles";
 import { noInlineFunctionParameterTypeAnnotation } from "./noInlineFunctionParameterTypeAnnotation";
 import { noLiteralJSXStylePropValues } from "./noLiteralJSXStylePropValues";
@@ -8,6 +9,7 @@ import { noUsePrefixForNonHook } from "./noUsePrefixForNonHook";
 import { preferTernaryForJSXExpressions } from "./preferTernaryForJSXExpressions";
 
 const rules = {
+    "css-module-import-name": cssModuleImportName,
     "no-inline-function-parameter-type-annotation":
         noInlineFunctionParameterTypeAnnotation,
     "no-mixed-exports": noMixedExports,

--- a/src/tests/cssModuleImportName.test.ts
+++ b/src/tests/cssModuleImportName.test.ts
@@ -13,10 +13,10 @@ const ruleTester = new RuleTester({
 
 ruleTester.run("cssModuleImportName", cssModuleImportName, {
     valid: [
-        // Default option: "classes"
+        // Default option: "classes" with different filenames and extensions
         'import classes from "./styles.module.css";',
-        'import classes from "./styles.module.scss";',
-        'import classes from "./styles.module.less";',
+        'import classes from "./Component.module.scss";',
+        'import classes from "./header.module.less";',
         // Non-CSS-module imports should be ignored
         'import styles from "./styles.css";',
         'import foo from "./foo";',
@@ -29,9 +29,17 @@ ruleTester.run("cssModuleImportName", cssModuleImportName, {
         'import * as styles from "./styles.module.css";',
         // Default + named together should be ignored
         'import classes, { something } from "./styles.module.css";',
-        // Custom option
+        // Custom option with different filenames
         {
-            code: 'import styles from "./styles.module.css";',
+            code: 'import styles from "./Button.module.css";',
+            options: [{ name: "styles" }],
+        },
+        {
+            code: 'import styles from "./layout.module.scss";',
+            options: [{ name: "styles" }],
+        },
+        {
+            code: 'import styles from "./theme.module.less";',
             options: [{ name: "styles" }],
         },
     ],
@@ -47,39 +55,39 @@ ruleTester.run("cssModuleImportName", cssModuleImportName, {
             output: 'import classes from "./styles.module.css";',
         },
         {
-            code: 'import s from "./component.module.scss";',
+            code: 'import s from "./Button.module.scss";',
             errors: [
                 {
                     messageId: "cssModuleImportName" as const,
                     data: { expected: "classes", actual: "s" },
                 },
             ],
-            output: 'import classes from "./component.module.scss";',
+            output: 'import classes from "./Button.module.scss";',
         },
         {
-            code: 'import css from "./component.module.less";',
+            code: 'import css from "./header.module.less";',
             errors: [
                 {
                     messageId: "cssModuleImportName" as const,
                     data: { expected: "classes", actual: "css" },
                 },
             ],
-            output: 'import classes from "./component.module.less";',
+            output: 'import classes from "./header.module.less";',
         },
         // Deeper import path
         {
-            code: 'import styles from "../../shared/styles.module.css";',
+            code: 'import styles from "../../shared/layout.module.css";',
             errors: [
                 {
                     messageId: "cssModuleImportName" as const,
                     data: { expected: "classes", actual: "styles" },
                 },
             ],
-            output: 'import classes from "../../shared/styles.module.css";',
+            output: 'import classes from "../../shared/layout.module.css";',
         },
         // Custom option: should report when not matching custom name
         {
-            code: 'import classes from "./styles.module.css";',
+            code: 'import classes from "./Card.module.css";',
             options: [{ name: "styles" }],
             errors: [
                 {
@@ -87,7 +95,7 @@ ruleTester.run("cssModuleImportName", cssModuleImportName, {
                     data: { expected: "styles", actual: "classes" },
                 },
             ],
-            output: 'import styles from "./styles.module.css";',
+            output: 'import styles from "./Card.module.css";',
         },
     ],
 });

--- a/src/tests/cssModuleImportName.test.ts
+++ b/src/tests/cssModuleImportName.test.ts
@@ -1,0 +1,93 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import * as vitest from "vitest";
+import { cssModuleImportName } from "../rules/cssModuleImportName";
+
+RuleTester.afterAll = vitest.afterAll;
+RuleTester.it = vitest.it;
+RuleTester.itOnly = vitest.it.only;
+RuleTester.describe = vitest.describe;
+
+const ruleTester = new RuleTester({
+    parser: "@typescript-eslint/parser",
+});
+
+ruleTester.run("cssModuleImportName", cssModuleImportName, {
+    valid: [
+        // Default option: "classes"
+        'import classes from "./styles.module.css";',
+        'import classes from "./styles.module.scss";',
+        'import classes from "./styles.module.less";',
+        // Non-CSS-module imports should be ignored
+        'import styles from "./styles.css";',
+        'import foo from "./foo";',
+        'import React from "react";',
+        // Named imports should be ignored
+        'import { something } from "./styles.module.css";',
+        // Side-effect imports should be ignored
+        'import "./styles.module.css";',
+        // Namespace imports should be ignored
+        'import * as styles from "./styles.module.css";',
+        // Default + named together should be ignored
+        'import classes, { something } from "./styles.module.css";',
+        // Custom option
+        {
+            code: 'import styles from "./styles.module.css";',
+            options: [{ name: "styles" }],
+        },
+    ],
+    invalid: [
+        {
+            code: 'import styles from "./styles.module.css";',
+            errors: [
+                {
+                    messageId: "cssModuleImportName" as const,
+                    data: { expected: "classes", actual: "styles" },
+                },
+            ],
+            output: 'import classes from "./styles.module.css";',
+        },
+        {
+            code: 'import s from "./component.module.scss";',
+            errors: [
+                {
+                    messageId: "cssModuleImportName" as const,
+                    data: { expected: "classes", actual: "s" },
+                },
+            ],
+            output: 'import classes from "./component.module.scss";',
+        },
+        {
+            code: 'import css from "./component.module.less";',
+            errors: [
+                {
+                    messageId: "cssModuleImportName" as const,
+                    data: { expected: "classes", actual: "css" },
+                },
+            ],
+            output: 'import classes from "./component.module.less";',
+        },
+        // Deeper import path
+        {
+            code: 'import styles from "../../shared/styles.module.css";',
+            errors: [
+                {
+                    messageId: "cssModuleImportName" as const,
+                    data: { expected: "classes", actual: "styles" },
+                },
+            ],
+            output: 'import classes from "../../shared/styles.module.css";',
+        },
+        // Custom option: should report when not matching custom name
+        {
+            code: 'import classes from "./styles.module.css";',
+            options: [{ name: "styles" }],
+            errors: [
+                {
+                    messageId: "cssModuleImportName" as const,
+                    data: { expected: "styles", actual: "classes" },
+                },
+            ],
+            output: 'import styles from "./styles.module.css";',
+        },
+    ],
+});


### PR DESCRIPTION
This PR adds a new rule `css-module-import-name` that can be used to enforce the name of a css module import.
For example, we want to enforce that css modules are imported like this `import classes from "./style.module.css"` and not `import styles from "./style.module.css"`, the name can be configured.