### PR TITLE
Add require-button-type rule

### DIFF
--- a/.changeset/require-button-type.md
+++ b/.changeset/require-button-type.md
@@ -1,0 +1,5 @@
+---
+"@meitner/eslint-plugin": minor
+---
+
+Added `require-button-type` rule

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Custom ESLint rules used internally at Meitner
 -   [always-spread-jsx-props-first](#always-spread-jsx-props-first)
 -   [no-exported-types-in-tsx-files](#no-exported-types-in-tsx-files)
 -   [css-module-import-name](#css-module-import-name)
+-   [require-button-type](#require-button-type)
 
 ### prefer-ternary-for-jsx-expressions
 
@@ -282,4 +283,30 @@ Examples of invalid code
 import styles from "./styles.module.css";
 import css from "./styles.module.scss";
 import s from "./styles.module.less";
+```
+
+### require-button-type
+
+When the `type` attribute is omitted, native `<button>` elements default to `type="submit"`. Inside a form this causes the button to submit the form, which is a common source of unintended behavior.
+
+This rule forces native `<button>` elements to explicitly specify a `type`. It only applies to the lowercase `button` element, so React components such as `<Button />` are ignored. A spread attribute (`{...props}`) does not satisfy the rule, since the presence of a `type` cannot be verified statically.
+
+Examples of valid code
+
+```tsx
+<button type="button">Click</button>
+
+<button type="submit">Submit</button>
+
+<button type={buttonType}>Click</button>
+```
+
+Examples of invalid code
+
+```tsx
+<button>Click</button>
+
+<button onClick={handleClick}>Click</button>
+
+<button {...props}>Click</button>
 ```

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -7,6 +7,7 @@ import { noMixedExports } from "./noMixedExports";
 import { noReactNamespace } from "./noReactNamespace";
 import { noUsePrefixForNonHook } from "./noUsePrefixForNonHook";
 import { preferTernaryForJSXExpressions } from "./preferTernaryForJSXExpressions";
+import { requireButtonType } from "./requireButtonType";
 
 const rules = {
     "css-module-import-name": cssModuleImportName,
@@ -19,6 +20,7 @@ const rules = {
     "always-spread-props-first": alwaysSpreadJSXPropsFirst,
     "no-exported-types-in-tsx-files": noExportedTypesInTsxFiles,
     "prefer-ternary-for-jsx-expressions": preferTernaryForJSXExpressions,
+    "require-button-type": requireButtonType,
 };
 
 export { rules };

--- a/src/rules/requireButtonType.ts
+++ b/src/rules/requireButtonType.ts
@@ -1,0 +1,42 @@
+import { ESLintUtils } from "@typescript-eslint/utils";
+
+export const requireButtonType = ESLintUtils.RuleCreator.withoutDocs({
+    create(context) {
+        return {
+            JSXOpeningElement(node) {
+                // Only target native <button> elements, not React components like <Button />
+                if (
+                    node.name.type !== "JSXIdentifier" ||
+                    node.name.name !== "button"
+                ) {
+                    return;
+                }
+
+                const hasTypeAttribute = node.attributes.some(
+                    (attribute) =>
+                        attribute.type === "JSXAttribute" &&
+                        attribute.name.type === "JSXIdentifier" &&
+                        attribute.name.name === "type"
+                );
+
+                if (hasTypeAttribute) {
+                    return;
+                }
+
+                context.report({
+                    node,
+                    messageId: "requireButtonType",
+                });
+            },
+        };
+    },
+    meta: {
+        messages: {
+            requireButtonType:
+                'type="submit" is the default for <button> elements, please explicitly specify the type.',
+        },
+        type: "problem",
+        schema: [],
+    },
+    defaultOptions: [],
+});

--- a/src/tests/requireButtonType.test.ts
+++ b/src/tests/requireButtonType.test.ts
@@ -1,0 +1,85 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import * as vitest from "vitest";
+import { requireButtonType } from "../rules/requireButtonType";
+
+RuleTester.afterAll = vitest.afterAll;
+RuleTester.it = vitest.it;
+RuleTester.itOnly = vitest.it.only;
+RuleTester.describe = vitest.describe;
+
+const ruleTester = new RuleTester({
+    parser: "@typescript-eslint/parser",
+});
+
+ruleTester.run("requireButtonType", requireButtonType, {
+    valid: [
+        {
+            code: '<button type="button">Click</button>',
+            parserOptions: { ecmaFeatures: { jsx: true } },
+        },
+        {
+            code: '<button type="submit">Submit</button>',
+            parserOptions: { ecmaFeatures: { jsx: true } },
+        },
+        {
+            code: '<button type="reset" />',
+            parserOptions: { ecmaFeatures: { jsx: true } },
+        },
+        {
+            code: "<button type={buttonType}>Click</button>",
+            parserOptions: { ecmaFeatures: { jsx: true } },
+        },
+        {
+            code: '<button onClick={handleClick} type="button">Click</button>',
+            parserOptions: { ecmaFeatures: { jsx: true } },
+        },
+        // Not a native <button>, so it is ignored
+        {
+            code: "<Button>Click</Button>",
+            parserOptions: { ecmaFeatures: { jsx: true } },
+        },
+        {
+            code: "<div>Not a button</div>",
+            parserOptions: { ecmaFeatures: { jsx: true } },
+        },
+    ],
+    invalid: [
+        {
+            code: "<button>Click</button>",
+            parserOptions: { ecmaFeatures: { jsx: true } },
+            errors: [
+                {
+                    messageId: "requireButtonType",
+                },
+            ],
+        },
+        {
+            code: "<button />",
+            parserOptions: { ecmaFeatures: { jsx: true } },
+            errors: [
+                {
+                    messageId: "requireButtonType",
+                },
+            ],
+        },
+        {
+            code: "<button onClick={handleClick}>Click</button>",
+            parserOptions: { ecmaFeatures: { jsx: true } },
+            errors: [
+                {
+                    messageId: "requireButtonType",
+                },
+            ],
+        },
+        // A spread attribute does not count as an explicit type
+        {
+            code: "<button {...props}>Click</button>",
+            parserOptions: { ecmaFeatures: { jsx: true } },
+            errors: [
+                {
+                    messageId: "requireButtonType",
+                },
+            ],
+        },
+    ],
+});


### PR DESCRIPTION
## What

Adds a new `require-button-type` rule that enforces an explicit `type` attribute on native `<button>` elements.

## Why

When `type` is omitted, native `<button>` elements default to `type="submit"`. Inside a form this submits the form — a common source of unintended behavior. The rule forces the choice to be explicit.

## Behavior

- Only matches the lowercase native `button`; React components like `<Button />` are ignored.
- A dynamic value (`<button type={buttonType} />`) counts as explicit and is allowed.
- A spread (`<button {...props} />`) is **reported**, since the presence of `type` can't be verified statically.

Enable with:

```json
"@meitner/require-button-type": "error"
```

## Verification

- `yarn test` — all 115 tests pass (11 new)
- `yarn typecheck` — clean
- `yarn lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)