### PR TITLE
Add require-reduce-initial-value rule

### DIFF
--- a/.changeset/require-reduce-initial-value.md
+++ b/.changeset/require-reduce-initial-value.md
@@ -2,4 +2,4 @@
 "@meitner/eslint-plugin": minor
 ---
 
-Add `require-reduce-initial-value` rule, which requires an `initialValue` argument to be passed to `.reduce()` and `.reduceRight()`. This replaces a `no-restricted-syntax` selector so it can be used as a JS plugin with oxlint.
+Added `require-reduce-initial-value` rule, which requires an `initialValue` argument to be passed to `.reduce()` and `.reduceRight()`.

--- a/.changeset/require-reduce-initial-value.md
+++ b/.changeset/require-reduce-initial-value.md
@@ -1,0 +1,5 @@
+---
+"@meitner/eslint-plugin": minor
+---
+
+Add `require-reduce-initial-value` rule, which requires an `initialValue` argument to be passed to `.reduce()`. This replaces a `no-restricted-syntax` selector so it can be used as a JS plugin with oxlint.

--- a/.changeset/require-reduce-initial-value.md
+++ b/.changeset/require-reduce-initial-value.md
@@ -2,4 +2,4 @@
 "@meitner/eslint-plugin": minor
 ---
 
-Add `require-reduce-initial-value` rule, which requires an `initialValue` argument to be passed to `.reduce()`. This replaces a `no-restricted-syntax` selector so it can be used as a JS plugin with oxlint.
+Add `require-reduce-initial-value` rule, which requires an `initialValue` argument to be passed to `.reduce()` and `.reduceRight()`. This replaces a `no-restricted-syntax` selector so it can be used as a JS plugin with oxlint.

--- a/README.md
+++ b/README.md
@@ -314,16 +314,16 @@ Examples of invalid code
 
 ### require-reduce-initial-value
 
-Calling `.reduce()` without an initial value throws a `TypeError` on empty arrays, and lets the accumulator type be inferred from the first element, which is rarely what you want.
+Calling `.reduce()` or `.reduceRight()` without an initial value throws a `TypeError` on empty arrays, and lets the accumulator type be inferred from the first element, which is rarely what you want.
 
-This rule requires an `initialValue` argument to be passed to `.reduce()`, mirroring the `CallExpression[arguments.length=1] > MemberExpression.callee > Identifier.property[name='reduce']` selector so it can be used with linters that do not support `no-restricted-syntax` (e.g. oxlint).
+This rule requires an `initialValue` argument to be passed to `.reduce()` and `.reduceRight()`. It is a JS-plugin replacement for a `no-restricted-syntax` selector, usable with linters that do not support `no-restricted-syntax` (e.g. oxlint).
 
 Examples of valid code
 
 ```ts
 arr.reduce((acc, cur) => acc + cur, 0);
 
-arr.reduce(reducer, initialValue);
+arr.reduceRight(reducer, initialValue);
 ```
 
 Examples of invalid code
@@ -331,5 +331,5 @@ Examples of invalid code
 ```ts
 arr.reduce((acc, cur) => acc + cur);
 
-arr.reduce(reducer);
+arr.reduceRight(reducer);
 ```

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ Examples of invalid code
 
 Calling `.reduce()` or `.reduceRight()` without an initial value throws a `TypeError` on empty arrays, and lets the accumulator type be inferred from the first element, which is rarely what you want.
 
-This rule requires an `initialValue` argument to be passed to `.reduce()` and `.reduceRight()`. It is a JS-plugin replacement for a `no-restricted-syntax` selector, usable with linters that do not support `no-restricted-syntax` (e.g. oxlint).
+This rule requires an `initialValue` argument to be passed to `.reduce()` and `.reduceRight()`.
 
 Examples of valid code
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Custom ESLint rules used internally at Meitner
 -   [no-exported-types-in-tsx-files](#no-exported-types-in-tsx-files)
 -   [css-module-import-name](#css-module-import-name)
 -   [require-button-type](#require-button-type)
+-   [require-reduce-initial-value](#require-reduce-initial-value)
 
 ### prefer-ternary-for-jsx-expressions
 
@@ -309,4 +310,26 @@ Examples of invalid code
 <button onClick={handleClick}>Click</button>
 
 <button {...props}>Click</button>
+```
+
+### require-reduce-initial-value
+
+Calling `.reduce()` without an initial value throws a `TypeError` on empty arrays, and lets the accumulator type be inferred from the first element, which is rarely what you want.
+
+This rule requires an `initialValue` argument to be passed to `.reduce()`, mirroring the `CallExpression[arguments.length=1] > MemberExpression.callee > Identifier.property[name='reduce']` selector so it can be used with linters that do not support `no-restricted-syntax` (e.g. oxlint).
+
+Examples of valid code
+
+```ts
+arr.reduce((acc, cur) => acc + cur, 0);
+
+arr.reduce(reducer, initialValue);
+```
+
+Examples of invalid code
+
+```ts
+arr.reduce((acc, cur) => acc + cur);
+
+arr.reduce(reducer);
 ```

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -8,6 +8,7 @@ import { noReactNamespace } from "./noReactNamespace";
 import { noUsePrefixForNonHook } from "./noUsePrefixForNonHook";
 import { preferTernaryForJSXExpressions } from "./preferTernaryForJSXExpressions";
 import { requireButtonType } from "./requireButtonType";
+import { requireReduceInitialValue } from "./requireReduceInitialValue";
 
 const rules = {
     "css-module-import-name": cssModuleImportName,
@@ -21,6 +22,7 @@ const rules = {
     "no-exported-types-in-tsx-files": noExportedTypesInTsxFiles,
     "prefer-ternary-for-jsx-expressions": preferTernaryForJSXExpressions,
     "require-button-type": requireButtonType,
+    "require-reduce-initial-value": requireReduceInitialValue,
 };
 
 export { rules };

--- a/src/rules/requireReduceInitialValue.ts
+++ b/src/rules/requireReduceInitialValue.ts
@@ -1,0 +1,29 @@
+import { ESLintUtils } from "@typescript-eslint/utils";
+
+export const requireReduceInitialValue = ESLintUtils.RuleCreator.withoutDocs({
+    create(context) {
+        return {
+            CallExpression(node) {
+                if (
+                    node.arguments.length === 1 &&
+                    node.callee.type === "MemberExpression" &&
+                    node.callee.property.type === "Identifier" &&
+                    node.callee.property.name === "reduce"
+                ) {
+                    context.report({
+                        node: node.callee.property,
+                        messageId: "requireReduceInitialValue",
+                    });
+                }
+            },
+        };
+    },
+    meta: {
+        messages: {
+            requireReduceInitialValue: "Provide initialValue to .reduce().",
+        },
+        type: "problem",
+        schema: [],
+    },
+    defaultOptions: [],
+});

--- a/src/rules/requireReduceInitialValue.ts
+++ b/src/rules/requireReduceInitialValue.ts
@@ -1,5 +1,7 @@
 import { ESLintUtils } from "@typescript-eslint/utils";
 
+const REDUCE_METHODS = new Set(["reduce", "reduceRight"]);
+
 export const requireReduceInitialValue = ESLintUtils.RuleCreator.withoutDocs({
     create(context) {
         return {
@@ -8,11 +10,14 @@ export const requireReduceInitialValue = ESLintUtils.RuleCreator.withoutDocs({
                     node.arguments.length === 1 &&
                     node.callee.type === "MemberExpression" &&
                     node.callee.property.type === "Identifier" &&
-                    node.callee.property.name === "reduce"
+                    REDUCE_METHODS.has(node.callee.property.name)
                 ) {
                     context.report({
                         node: node.callee.property,
                         messageId: "requireReduceInitialValue",
+                        data: {
+                            method: node.callee.property.name,
+                        },
                     });
                 }
             },
@@ -20,7 +25,7 @@ export const requireReduceInitialValue = ESLintUtils.RuleCreator.withoutDocs({
     },
     meta: {
         messages: {
-            requireReduceInitialValue: "Provide initialValue to .reduce().",
+            requireReduceInitialValue: "Provide initialValue to .{{ method }}().",
         },
         type: "problem",
         schema: [],

--- a/src/tests/requireReduceInitialValue.test.ts
+++ b/src/tests/requireReduceInitialValue.test.ts
@@ -1,0 +1,47 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import * as vitest from "vitest";
+import { requireReduceInitialValue } from "../rules/requireReduceInitialValue";
+
+RuleTester.afterAll = vitest.afterAll;
+RuleTester.it = vitest.it;
+RuleTester.itOnly = vitest.it.only;
+RuleTester.describe = vitest.describe;
+
+const ruleTester = new RuleTester({
+    parser: "@typescript-eslint/parser",
+});
+
+ruleTester.run("requireReduceInitialValue", requireReduceInitialValue, {
+    valid: [
+        "arr.reduce((acc, cur) => acc + cur, 0);",
+        "arr.reduce(reducer, initialValue);",
+        "arr.reduce(reducer, {});",
+        // A different method entirely
+        "arr.map(fn);",
+        // A bare function call, not a member call
+        "reduce(fn);",
+        // reduceRight is not covered by the selector
+        "arr.reduceRight(fn);",
+        // Computed access is intentionally not matched (mirrors the original
+        // selector, which only targets `Identifier.property`)
+        'arr["reduce"](fn);',
+    ],
+    invalid: [
+        {
+            code: "arr.reduce((acc, cur) => acc + cur);",
+            errors: [{ messageId: "requireReduceInitialValue" }],
+        },
+        {
+            code: "arr.reduce(reducer);",
+            errors: [{ messageId: "requireReduceInitialValue" }],
+        },
+        {
+            code: "arr.filter(Boolean).reduce(reducer);",
+            errors: [{ messageId: "requireReduceInitialValue" }],
+        },
+        {
+            code: "arr?.reduce(reducer);",
+            errors: [{ messageId: "requireReduceInitialValue" }],
+        },
+    ],
+});

--- a/src/tests/requireReduceInitialValue.test.ts
+++ b/src/tests/requireReduceInitialValue.test.ts
@@ -16,12 +16,11 @@ ruleTester.run("requireReduceInitialValue", requireReduceInitialValue, {
         "arr.reduce((acc, cur) => acc + cur, 0);",
         "arr.reduce(reducer, initialValue);",
         "arr.reduce(reducer, {});",
+        "arr.reduceRight(reducer, initialValue);",
         // A different method entirely
         "arr.map(fn);",
         // A bare function call, not a member call
         "reduce(fn);",
-        // reduceRight is not covered by the selector
-        "arr.reduceRight(fn);",
         // Computed access is intentionally not matched (mirrors the original
         // selector, which only targets `Identifier.property`)
         'arr["reduce"](fn);',
@@ -29,11 +28,25 @@ ruleTester.run("requireReduceInitialValue", requireReduceInitialValue, {
     invalid: [
         {
             code: "arr.reduce((acc, cur) => acc + cur);",
-            errors: [{ messageId: "requireReduceInitialValue" }],
+            errors: [
+                {
+                    messageId: "requireReduceInitialValue",
+                    data: { method: "reduce" },
+                },
+            ],
         },
         {
             code: "arr.reduce(reducer);",
             errors: [{ messageId: "requireReduceInitialValue" }],
+        },
+        {
+            code: "arr.reduceRight(reducer);",
+            errors: [
+                {
+                    messageId: "requireReduceInitialValue",
+                    data: { method: "reduceRight" },
+                },
+            ],
         },
         {
             code: "arr.filter(Boolean).reduce(reducer);",


### PR DESCRIPTION
## What

Adds a new `require-reduce-initial-value` rule that requires an `initialValue` argument to be passed to `.reduce()` and `.reduceRight()`.

## Why

Calling `.reduce()` / `.reduceRight()` without an initial value throws a `TypeError` on empty arrays and lets the accumulator type be inferred from the first element, which is rarely what you want. The rule forces the initial value to be explicit.

## Behavior

- Covers both `.reduce()` and `.reduceRight()`; the reported message names the actual method (`Provide initialValue to .reduceRight().`).
- Only matches a member call with an `Identifier` property, so computed access (`arr["reduce"](fn)`) is not flagged.
- Optional chaining (`arr?.reduce(fn)`) is flagged.

Enable with:

```json
"@meitner/require-reduce-initial-value": "error"
```

## Verification

- `vitest run` — full suite passes (12 new tests for this rule)
- `tsc --noEmit` — clean
- `eslint . --ext .ts --max-warnings 0` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)