### PR TITLE
Add no-hook-result-member-access and no-hook-result-as-argument rules

### DIFF
--- a/.changeset/hook-result-rules.md
+++ b/.changeset/hook-result-rules.md
@@ -2,4 +2,4 @@
 "@meitner/eslint-plugin": minor
 ---
 
-Add `no-hook-result-member-access` and `no-hook-result-as-argument` rules, which require a hook's result to be assigned to a variable (or destructured) instead of being accessed or passed inline, e.g. `useLocation().pathname` or `new URLSearchParams(useLocationSearch())`.
+Add `no-hook-result-member-access` and `no-hook-result-as-argument` rules, which require a hook's result to be assigned to a variable (or destructured) instead of being accessed or passed inline, e.g. `useHook().property` or `doSomething(useHook())`.

--- a/.changeset/hook-result-rules.md
+++ b/.changeset/hook-result-rules.md
@@ -1,0 +1,5 @@
+---
+"@meitner/eslint-plugin": minor
+---
+
+Add `no-hook-result-member-access` and `no-hook-result-as-argument` rules, which require a hook's result to be assigned to a variable (or destructured) instead of being accessed or passed inline, e.g. `useLocation().pathname` or `new URLSearchParams(useLocationSearch())`.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Custom ESLint rules used internally at Meitner
 -   [css-module-import-name](#css-module-import-name)
 -   [require-button-type](#require-button-type)
 -   [require-reduce-initial-value](#require-reduce-initial-value)
+-   [no-hook-result-member-access](#no-hook-result-member-access)
+-   [no-hook-result-as-argument](#no-hook-result-as-argument)
 
 ### prefer-ternary-for-jsx-expressions
 
@@ -332,4 +334,50 @@ Examples of invalid code
 arr.reduce((acc, cur) => acc + cur);
 
 arr.reduceRight(reducer);
+```
+
+### no-hook-result-member-access
+
+Reading a member off a hook call directly (`useLocation().pathname`) hides the hook call inside a larger expression and throws away the rest of its result. When it happens more than once it also calls the hook repeatedly for a single value each time.
+
+This rule requires the result of a hook (a function whose name matches `use[A-Z]`) to be assigned to a variable or destructured before its members are accessed.
+
+Examples of valid code
+
+```ts
+const { pathname } = useLocation();
+
+const location = useLocation();
+const pathname = location.pathname;
+```
+
+Examples of invalid code
+
+```ts
+const pathname = useLocation().pathname;
+
+const searchParams = new URLSearchParams(useLocation().search);
+
+const t = useTranslation().t;
+```
+
+### no-hook-result-as-argument
+
+Passing a hook call straight into another call or constructor (`new URLSearchParams(useLocationSearch())`) buries the hook inside an argument list, where it is easy to miss that a hook is being called at all.
+
+This rule requires the result of a hook (a function whose name matches `use[A-Z]`) to be assigned to a variable before it is passed as an argument. Member access on a hook result is handled by [no-hook-result-member-access](#no-hook-result-member-access) instead.
+
+Examples of valid code
+
+```ts
+const search = useLocationSearch();
+const searchParams = new URLSearchParams(search);
+```
+
+Examples of invalid code
+
+```ts
+const searchParams = new URLSearchParams(useLocationSearch());
+
+doSomething(useSelector(selector));
 ```

--- a/README.md
+++ b/README.md
@@ -338,46 +338,46 @@ arr.reduceRight(reducer);
 
 ### no-hook-result-member-access
 
-Reading a member off a hook call directly (`useLocation().pathname`) hides the hook call inside a larger expression and throws away the rest of its result. When it happens more than once it also calls the hook repeatedly for a single value each time.
+Reading a member off a hook call directly (`useHook().property`) hides the hook call inside a larger expression and throws away the rest of its result. When it happens more than once it also calls the hook repeatedly for a single value each time.
 
 This rule requires the result of a hook (a function whose name matches `use[A-Z]`) to be assigned to a variable or destructured before its members are accessed.
 
 Examples of valid code
 
 ```ts
-const { pathname } = useLocation();
+const { property } = useHook();
 
-const location = useLocation();
-const pathname = location.pathname;
+const result = useHook();
+const property = result.property;
 ```
 
 Examples of invalid code
 
 ```ts
-const pathname = useLocation().pathname;
+const property = useHook().property;
 
-const searchParams = new URLSearchParams(useLocation().search);
+const instance = new SomeClass(useHook().property);
 
-const t = useTranslation().t;
+useHook().doSomething();
 ```
 
 ### no-hook-result-as-argument
 
-Passing a hook call straight into another call or constructor (`new URLSearchParams(useLocationSearch())`) buries the hook inside an argument list, where it is easy to miss that a hook is being called at all.
+Passing a hook call straight into another call or constructor (`doSomething(useHook())`) buries the hook inside an argument list, where it is easy to miss that a hook is being called at all.
 
 This rule requires the result of a hook (a function whose name matches `use[A-Z]`) to be assigned to a variable before it is passed as an argument. Member access on a hook result is handled by [no-hook-result-member-access](#no-hook-result-member-access) instead.
 
 Examples of valid code
 
 ```ts
-const search = useLocationSearch();
-const searchParams = new URLSearchParams(search);
+const value = useHook();
+doSomething(value);
 ```
 
 Examples of invalid code
 
 ```ts
-const searchParams = new URLSearchParams(useLocationSearch());
+doSomething(useHook());
 
-doSomething(useSelector(selector));
+const instance = new SomeClass(useHook());
 ```

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,6 +1,8 @@
 import { alwaysSpreadJSXPropsFirst } from "./alwaysSpreadJSXPropsFirst";
 import { cssModuleImportName } from "./cssModuleImportName";
 import { noExportedTypesInTsxFiles } from "./noExportedTypesInTsxFiles";
+import { noHookResultAsArgument } from "./noHookResultAsArgument";
+import { noHookResultMemberAccess } from "./noHookResultMemberAccess";
 import { noInlineFunctionParameterTypeAnnotation } from "./noInlineFunctionParameterTypeAnnotation";
 import { noLiteralJSXStylePropValues } from "./noLiteralJSXStylePropValues";
 import { noMixedExports } from "./noMixedExports";
@@ -23,6 +25,8 @@ const rules = {
     "prefer-ternary-for-jsx-expressions": preferTernaryForJSXExpressions,
     "require-button-type": requireButtonType,
     "require-reduce-initial-value": requireReduceInitialValue,
+    "no-hook-result-member-access": noHookResultMemberAccess,
+    "no-hook-result-as-argument": noHookResultAsArgument,
 };
 
 export { rules };

--- a/src/rules/noHookResultAsArgument.ts
+++ b/src/rules/noHookResultAsArgument.ts
@@ -1,0 +1,43 @@
+import { ESLintUtils } from "@typescript-eslint/utils";
+
+const HOOK_NAME = /^use[A-Z]/;
+
+export const noHookResultAsArgument = ESLintUtils.RuleCreator.withoutDocs({
+    create(context) {
+        return {
+            CallExpression(node) {
+                if (
+                    node.callee.type !== "Identifier" ||
+                    !HOOK_NAME.test(node.callee.name)
+                ) {
+                    return;
+                }
+
+                const parent = node.parent;
+
+                if (
+                    (parent.type === "CallExpression" ||
+                        parent.type === "NewExpression") &&
+                    parent.arguments.includes(node)
+                ) {
+                    context.report({
+                        node,
+                        messageId: "noHookResultAsArgument",
+                        data: {
+                            hook: node.callee.name,
+                        },
+                    });
+                }
+            },
+        };
+    },
+    meta: {
+        messages: {
+            noHookResultAsArgument:
+                "Assign the result of {{ hook }}() to a variable instead of passing the call directly as an argument.",
+        },
+        type: "problem",
+        schema: [],
+    },
+    defaultOptions: [],
+});

--- a/src/rules/noHookResultMemberAccess.ts
+++ b/src/rules/noHookResultMemberAccess.ts
@@ -1,0 +1,34 @@
+import { ESLintUtils } from "@typescript-eslint/utils";
+
+const HOOK_NAME = /^use[A-Z]/;
+
+export const noHookResultMemberAccess = ESLintUtils.RuleCreator.withoutDocs({
+    create(context) {
+        return {
+            MemberExpression(node) {
+                if (
+                    node.object.type === "CallExpression" &&
+                    node.object.callee.type === "Identifier" &&
+                    HOOK_NAME.test(node.object.callee.name)
+                ) {
+                    context.report({
+                        node: node.object,
+                        messageId: "noHookResultMemberAccess",
+                        data: {
+                            hook: node.object.callee.name,
+                        },
+                    });
+                }
+            },
+        };
+    },
+    meta: {
+        messages: {
+            noHookResultMemberAccess:
+                "Assign the result of {{ hook }}() to a variable, or destructure it, instead of accessing its members on the call directly.",
+        },
+        type: "problem",
+        schema: [],
+    },
+    defaultOptions: [],
+});

--- a/src/tests/noHookResultAsArgument.test.ts
+++ b/src/tests/noHookResultAsArgument.test.ts
@@ -14,58 +14,58 @@ const ruleTester = new RuleTester({
 ruleTester.run("noHookResultAsArgument", noHookResultAsArgument, {
     valid: [
         // Assigned to a variable first, then passed
-        "const search = useLocationSearch(); new URLSearchParams(search);",
+        "const value = useHook(); doSomething(value);",
         // Assigned, not passed inline
-        "const params = useSearchParams();",
-        // Bare statement, result discarded
-        "useEffect(() => {}, []);",
+        "const value = useHook();",
+        // Bare call, result discarded
+        "useHook();",
         // The hook's own arguments are not hook calls
-        "const value = useMemo(() => compute(), []);",
+        "const value = useHook(callback, deps);",
         // Passing the hook reference (not calling it) is fine
-        "wrapHook(useLocation);",
+        "wrap(useHook);",
         // Argument is not a hook call
-        "new URLSearchParams(getSearch());",
+        "new SomeClass(getValue());",
         "doSomething(computeValue());",
         // Immediately invoking the hook result is a call position, not an
         // argument position — intentionally out of scope for this rule
-        "useEventHandler()();",
+        "useHook()();",
     ],
     invalid: [
         {
-            code: "const search = new URLSearchParams(useLocationSearch());",
+            code: "const instance = new SomeClass(useHook());",
             errors: [
                 {
                     messageId: "noHookResultAsArgument",
-                    data: { hook: "useLocationSearch" },
+                    data: { hook: "useHook" },
                 },
             ],
         },
         {
-            code: "foo(useX());",
+            code: "doSomething(useHook());",
             errors: [
                 {
                     messageId: "noHookResultAsArgument",
-                    data: { hook: "useX" },
+                    data: { hook: "useHook" },
                 },
             ],
         },
         // The hook call itself is the argument, even when it takes its own args
         {
-            code: "doSomething(useSelector(selector));",
+            code: "doSomething(useOther(config));",
             errors: [
                 {
                     messageId: "noHookResultAsArgument",
-                    data: { hook: "useSelector" },
+                    data: { hook: "useOther" },
                 },
             ],
         },
         // A hook argument alongside other arguments
         {
-            code: "new Foo(useBar(), other);",
+            code: "new SomeClass(useHook(), other);",
             errors: [
                 {
                     messageId: "noHookResultAsArgument",
-                    data: { hook: "useBar" },
+                    data: { hook: "useHook" },
                 },
             ],
         },

--- a/src/tests/noHookResultAsArgument.test.ts
+++ b/src/tests/noHookResultAsArgument.test.ts
@@ -1,0 +1,87 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import * as vitest from "vitest";
+import { noHookResultAsArgument } from "../rules/noHookResultAsArgument";
+
+RuleTester.afterAll = vitest.afterAll;
+RuleTester.it = vitest.it;
+RuleTester.itOnly = vitest.it.only;
+RuleTester.describe = vitest.describe;
+
+const ruleTester = new RuleTester({
+    parser: "@typescript-eslint/parser",
+});
+
+ruleTester.run("noHookResultAsArgument", noHookResultAsArgument, {
+    valid: [
+        // Assigned to a variable first, then passed
+        "const search = useLocationSearch(); new URLSearchParams(search);",
+        // Assigned, not passed inline
+        "const params = useSearchParams();",
+        // Bare statement, result discarded
+        "useEffect(() => {}, []);",
+        // The hook's own arguments are not hook calls
+        "const value = useMemo(() => compute(), []);",
+        // Passing the hook reference (not calling it) is fine
+        "wrapHook(useLocation);",
+        // Argument is not a hook call
+        "new URLSearchParams(getSearch());",
+        "doSomething(computeValue());",
+        // Immediately invoking the hook result is a call position, not an
+        // argument position — intentionally out of scope for this rule
+        "useEventHandler()();",
+    ],
+    invalid: [
+        {
+            code: "const search = new URLSearchParams(useLocationSearch());",
+            errors: [
+                {
+                    messageId: "noHookResultAsArgument",
+                    data: { hook: "useLocationSearch" },
+                },
+            ],
+        },
+        {
+            code: "foo(useX());",
+            errors: [
+                {
+                    messageId: "noHookResultAsArgument",
+                    data: { hook: "useX" },
+                },
+            ],
+        },
+        // The hook call itself is the argument, even when it takes its own args
+        {
+            code: "doSomething(useSelector(selector));",
+            errors: [
+                {
+                    messageId: "noHookResultAsArgument",
+                    data: { hook: "useSelector" },
+                },
+            ],
+        },
+        // A hook argument alongside other arguments
+        {
+            code: "new Foo(useBar(), other);",
+            errors: [
+                {
+                    messageId: "noHookResultAsArgument",
+                    data: { hook: "useBar" },
+                },
+            ],
+        },
+        // Multiple hook arguments each report
+        {
+            code: "combine(useA(), useB());",
+            errors: [
+                {
+                    messageId: "noHookResultAsArgument",
+                    data: { hook: "useA" },
+                },
+                {
+                    messageId: "noHookResultAsArgument",
+                    data: { hook: "useB" },
+                },
+            ],
+        },
+    ],
+});

--- a/src/tests/noHookResultMemberAccess.test.ts
+++ b/src/tests/noHookResultMemberAccess.test.ts
@@ -14,62 +14,66 @@ const ruleTester = new RuleTester({
 ruleTester.run("noHookResultMemberAccess", noHookResultMemberAccess, {
     valid: [
         // Destructured — the preferred form
-        "const { pathname } = useLocation();",
+        "const { property } = useHook();",
         // Assigned to a variable first, then accessed
-        "const location = useLocation(); const p = location.pathname;",
+        "const result = useHook(); const property = result.property;",
         // Assigned without any member access
-        "const value = useMemo(() => compute(), []);",
-        "const ref = useRef(0);",
-        // Effect hook called for its side effect, no member access
-        "useEffect(() => {}, []);",
+        "const value = useHook(config);",
+        // Bare call, no member access
+        "useHook();",
         // Not a hook name
-        "notAHook().pathname;",
-        "getState().value;",
+        "notAHook().property;",
+        "getValue().property;",
         // A namespaced call is not a bare hook identifier
-        "foo.useBar().baz;",
+        "obj.useHook().property;",
     ],
     invalid: [
         {
-            code: "const pathname = useLocation().pathname;",
+            code: "const property = useHook().property;",
             errors: [
                 {
                     messageId: "noHookResultMemberAccess",
-                    data: { hook: "useLocation" },
+                    data: { hook: "useHook" },
                 },
             ],
         },
         {
-            code: "useLocation().pathname;",
+            code: "useHook().property;",
             errors: [{ messageId: "noHookResultMemberAccess" }],
         },
         // Member access on a hook result, even nested inside another expression
         {
-            code: "const p = new URLSearchParams(useLocation().search);",
+            code: "const instance = new SomeClass(useHook().property);",
             errors: [
                 {
                     messageId: "noHookResultMemberAccess",
-                    data: { hook: "useLocation" },
+                    data: { hook: "useHook" },
                 },
             ],
         },
         {
-            code: "const t = useTranslation().t;",
-            errors: [{ messageId: "noHookResultMemberAccess" }],
+            code: "const value = useOther().value;",
+            errors: [
+                {
+                    messageId: "noHookResultMemberAccess",
+                    data: { hook: "useOther" },
+                },
+            ],
         },
         // Optional chaining still accesses a member on the call
         {
-            code: "const x = useLocation()?.pathname;",
+            code: "const x = useHook()?.property;",
             errors: [{ messageId: "noHookResultMemberAccess" }],
         },
         // Computed access
         {
-            code: 'const x = useLocation()["pathname"];',
+            code: 'const x = useHook()["property"];',
             errors: [{ messageId: "noHookResultMemberAccess" }],
         },
         // Calling a method on the hook result is member access, so this rule
         // owns it (not no-hook-result-as-argument)
         {
-            code: "useStore().subscribe();",
+            code: "useHook().doSomething();",
             errors: [{ messageId: "noHookResultMemberAccess" }],
         },
     ],

--- a/src/tests/noHookResultMemberAccess.test.ts
+++ b/src/tests/noHookResultMemberAccess.test.ts
@@ -1,0 +1,76 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import * as vitest from "vitest";
+import { noHookResultMemberAccess } from "../rules/noHookResultMemberAccess";
+
+RuleTester.afterAll = vitest.afterAll;
+RuleTester.it = vitest.it;
+RuleTester.itOnly = vitest.it.only;
+RuleTester.describe = vitest.describe;
+
+const ruleTester = new RuleTester({
+    parser: "@typescript-eslint/parser",
+});
+
+ruleTester.run("noHookResultMemberAccess", noHookResultMemberAccess, {
+    valid: [
+        // Destructured — the preferred form
+        "const { pathname } = useLocation();",
+        // Assigned to a variable first, then accessed
+        "const location = useLocation(); const p = location.pathname;",
+        // Assigned without any member access
+        "const value = useMemo(() => compute(), []);",
+        "const ref = useRef(0);",
+        // Effect hook called for its side effect, no member access
+        "useEffect(() => {}, []);",
+        // Not a hook name
+        "notAHook().pathname;",
+        "getState().value;",
+        // A namespaced call is not a bare hook identifier
+        "foo.useBar().baz;",
+    ],
+    invalid: [
+        {
+            code: "const pathname = useLocation().pathname;",
+            errors: [
+                {
+                    messageId: "noHookResultMemberAccess",
+                    data: { hook: "useLocation" },
+                },
+            ],
+        },
+        {
+            code: "useLocation().pathname;",
+            errors: [{ messageId: "noHookResultMemberAccess" }],
+        },
+        // Member access on a hook result, even nested inside another expression
+        {
+            code: "const p = new URLSearchParams(useLocation().search);",
+            errors: [
+                {
+                    messageId: "noHookResultMemberAccess",
+                    data: { hook: "useLocation" },
+                },
+            ],
+        },
+        {
+            code: "const t = useTranslation().t;",
+            errors: [{ messageId: "noHookResultMemberAccess" }],
+        },
+        // Optional chaining still accesses a member on the call
+        {
+            code: "const x = useLocation()?.pathname;",
+            errors: [{ messageId: "noHookResultMemberAccess" }],
+        },
+        // Computed access
+        {
+            code: 'const x = useLocation()["pathname"];',
+            errors: [{ messageId: "noHookResultMemberAccess" }],
+        },
+        // Calling a method on the hook result is member access, so this rule
+        // owns it (not no-hook-result-as-argument)
+        {
+            code: "useStore().subscribe();",
+            errors: [{ messageId: "noHookResultMemberAccess" }],
+        },
+    ],
+});


### PR DESCRIPTION
## What

Two new rules that catch a pattern seen across Claude-authored PRs — using a hook's return value inline instead of binding it to a variable:

```tsx
const pathname = useLocation().pathname;
const searchParams = new URLSearchParams(useLocation().searchStr);
```

Rather than one broad rule, these are split by the two consumption shapes so each can be adopted and tuned (`error`/`warn`) independently:

- **`no-hook-result-member-access`** — flags member access on a hook call, e.g. `useLocation().pathname`. Steers toward destructuring. Also owns method-call cases like `useStore().subscribe()`.
- **`no-hook-result-as-argument`** — flags a hook call passed straight into another call or constructor, e.g. `new URLSearchParams(useLocationSearch())`. Steers toward binding to a variable.

The scopes are **disjoint** (member access vs. argument position), so the two rules never double-report on the same node. Both match hooks by the `use[A-Z]` naming convention and are report-only (no autofix — hoisting a declaration and naming it isn't mechanical).

## Deliberate boundaries (covered by tests)

- Optional chaining (`useLocation()?.pathname`) and computed access (`useLocation()["pathname"]`) → caught by member-access rule.
- Effect hooks (`useEffect(() => {}, [])`), assigned/destructured results, and namespaced calls (`foo.useBar().baz`) → allowed.
- Immediately-invoked hook results (`useEventHandler()()`) and passing a hook *reference* (`wrapHook(useLocation)`) → intentionally not flagged.
- Multiple hook arguments (`combine(useA(), useB())`) → each reports.
- Operator/ternary operand positions (`useX() ?? fallback`) → intentionally left out; conditional hook calls are already `react-hooks/rules-of-hooks` territory.

## Test plan

- [x] `pnpm test` — 155 passing (28 new across the two suites)
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)