### PR TITLE
feat: add no-self-package-import rule

### DIFF
--- a/.changeset/no-self-package-import.md
+++ b/.changeset/no-self-package-import.md
@@ -1,0 +1,5 @@
+---
+"@meitner/eslint-plugin": minor
+---
+
+Add `no-self-package-import` rule: forbids a package from importing its own name (bare or subpath) — sibling modules should use relative paths. Reads each file's owning `package.json` name, so it needs no per-package configuration.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Custom ESLint rules used internally at Meitner
 -   [css-module-import-name](#css-module-import-name)
 -   [require-button-type](#require-button-type)
 -   [require-reduce-initial-value](#require-reduce-initial-value)
+-   [no-self-package-import](#no-self-package-import)
 
 ### prefer-ternary-for-jsx-expressions
 
@@ -332,4 +333,28 @@ Examples of invalid code
 arr.reduce((acc, cur) => acc + cur);
 
 arr.reduceRight(reducer);
+```
+
+### no-self-package-import
+
+A file inside a package should import its sibling modules with relative paths, not through the package's own name. Importing `@meitner/feature-x/components/foo` from within `@meitner/feature-x` is a self-reference: it round-trips through the package's export map (and, for the bare package name, its barrel) instead of pointing straight at the module.
+
+This rule reads the nearest `package.json` `name` for each file and reports any `import`/`export ... from` whose specifier is that same package — either the bare name or a subpath. Imports of _other_ packages, relative paths, and external modules are unaffected.
+
+Examples of valid code
+
+```ts
+// inside @meitner/feature-x
+import { foo } from "./foo";
+import { bar } from "../bar";
+import { baz } from "@meitner/feature-y/baz";
+```
+
+Examples of invalid code
+
+```ts
+// inside @meitner/feature-x
+import { foo } from "@meitner/feature-x/foo";
+import { helpers } from "@meitner/feature-x";
+export { bar } from "@meitner/feature-x/bar";
 ```

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -5,6 +5,7 @@ import { noInlineFunctionParameterTypeAnnotation } from "./noInlineFunctionParam
 import { noLiteralJSXStylePropValues } from "./noLiteralJSXStylePropValues";
 import { noMixedExports } from "./noMixedExports";
 import { noReactNamespace } from "./noReactNamespace";
+import { noSelfPackageImport } from "./noSelfPackageImport";
 import { noUsePrefixForNonHook } from "./noUsePrefixForNonHook";
 import { preferTernaryForJSXExpressions } from "./preferTernaryForJSXExpressions";
 import { requireButtonType } from "./requireButtonType";
@@ -17,6 +18,7 @@ const rules = {
     "no-mixed-exports": noMixedExports,
     "no-use-prefix-for-non-hook": noUsePrefixForNonHook,
     "no-react-namespace": noReactNamespace,
+    "no-self-package-import": noSelfPackageImport,
     "no-literal-jsx-style-prop-values": noLiteralJSXStylePropValues,
     "always-spread-props-first": alwaysSpreadJSXPropsFirst,
     "no-exported-types-in-tsx-files": noExportedTypesInTsxFiles,

--- a/src/rules/noSelfPackageImport.ts
+++ b/src/rules/noSelfPackageImport.ts
@@ -1,0 +1,98 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { ESLintUtils, TSESTree } from "@typescript-eslint/utils";
+
+/** dir -> owning package name (or null), memoized across files. */
+const packageNameCache = new Map<string, string | null>();
+
+/**
+ * Walk up from a file to the nearest package.json and return its `name`.
+ */
+function packageNameForFile(filename: string): string | null {
+    let dir = path.dirname(filename);
+    const visited: string[] = [];
+
+    while (dir && dir !== path.dirname(dir)) {
+        const cached = packageNameCache.get(dir);
+        if (cached !== undefined) {
+            for (const entry of visited) packageNameCache.set(entry, cached);
+            return cached;
+        }
+        visited.push(dir);
+
+        const pkgPath = path.join(dir, "package.json");
+        if (fs.existsSync(pkgPath)) {
+            let name: string | null = null;
+            try {
+                const parsed: unknown = JSON.parse(
+                    fs.readFileSync(pkgPath, "utf8")
+                );
+                if (
+                    typeof parsed === "object" &&
+                    parsed !== null &&
+                    "name" in parsed &&
+                    typeof parsed.name === "string"
+                ) {
+                    name = parsed.name;
+                }
+            } catch {
+                name = null;
+            }
+            for (const entry of visited) packageNameCache.set(entry, name);
+            return name;
+        }
+
+        dir = path.dirname(dir);
+    }
+
+    for (const entry of visited) packageNameCache.set(entry, null);
+    return null;
+}
+
+type SourcedNode =
+    | TSESTree.ImportDeclaration
+    | TSESTree.ExportNamedDeclaration
+    | TSESTree.ExportAllDeclaration;
+
+export const noSelfPackageImport = ESLintUtils.RuleCreator.withoutDocs({
+    create(context) {
+        const ownPackage = packageNameForFile(context.filename);
+        if (ownPackage === null) {
+            return {};
+        }
+
+        function check(node: SourcedNode) {
+            const source = node.source;
+            if (source === null || typeof source.value !== "string") {
+                return;
+            }
+            const specifier = source.value;
+            if (
+                specifier === ownPackage ||
+                specifier.startsWith(`${ownPackage}/`)
+            ) {
+                context.report({
+                    node: source,
+                    messageId: "selfImport",
+                    data: { pkg: ownPackage },
+                });
+            }
+        }
+
+        return {
+            ImportDeclaration: check,
+            ExportNamedDeclaration: check,
+            ExportAllDeclaration: check,
+        };
+    },
+    meta: {
+        messages: {
+            selfImport:
+                "Import sibling modules with a relative path, not this package's own name '{{pkg}}'.",
+        },
+        type: "problem",
+        schema: [],
+    },
+    defaultOptions: [],
+});

--- a/src/tests/noSelfPackageImport.test.ts
+++ b/src/tests/noSelfPackageImport.test.ts
@@ -1,0 +1,72 @@
+import path from "node:path";
+
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import * as vitest from "vitest";
+
+import { noSelfPackageImport } from "../rules/noSelfPackageImport";
+
+RuleTester.afterAll = vitest.afterAll;
+RuleTester.it = vitest.it;
+RuleTester.itOnly = vitest.it.only;
+RuleTester.describe = vitest.describe;
+
+const ruleTester = new RuleTester({
+    parser: "@typescript-eslint/parser",
+});
+
+// A file inside this repo resolves (via package.json walk-up) to the plugin's
+// own name, "@meitner/eslint-plugin".
+const fileInThisPackage = path.join(process.cwd(), "src", "example.ts");
+const parserOptions = { ecmaVersion: 2020, sourceType: "module" } as const;
+
+ruleTester.run("noSelfPackageImport", noSelfPackageImport, {
+    valid: [
+        {
+            code: `import { x } from "./sibling";`,
+            filename: fileInThisPackage,
+            parserOptions,
+        },
+        {
+            code: `import { x } from "@meitner/other-package/foo";`,
+            filename: fileInThisPackage,
+            parserOptions,
+        },
+        {
+            code: `import react from "react";`,
+            filename: fileInThisPackage,
+            parserOptions,
+        },
+        {
+            // Prefix of the package name but a different package — must not match.
+            code: `import { x } from "@meitner/eslint-plugin-extra/foo";`,
+            filename: fileInThisPackage,
+            parserOptions,
+        },
+    ],
+    invalid: [
+        {
+            code: `import { x } from "@meitner/eslint-plugin";`,
+            filename: fileInThisPackage,
+            parserOptions,
+            errors: [{ messageId: "selfImport" }],
+        },
+        {
+            code: `import { x } from "@meitner/eslint-plugin/rules/foo";`,
+            filename: fileInThisPackage,
+            parserOptions,
+            errors: [{ messageId: "selfImport" }],
+        },
+        {
+            code: `export { x } from "@meitner/eslint-plugin/rules/foo";`,
+            filename: fileInThisPackage,
+            parserOptions,
+            errors: [{ messageId: "selfImport" }],
+        },
+        {
+            code: `export * from "@meitner/eslint-plugin/rules/foo";`,
+            filename: fileInThisPackage,
+            parserOptions,
+            errors: [{ messageId: "selfImport" }],
+        },
+    ],
+});


### PR DESCRIPTION
## What

New rule **`no-self-package-import`**: forbids a package from importing its **own** name — sibling modules within a package must use relative paths.

```ts
// inside @meitner/feature-x
import { foo } from "@meitner/feature-x/foo"; // ❌
import { helpers } from "@meitner/feature-x"; // ❌ (bare/barrel)
import { foo } from "./foo";                  // ✅
import { baz } from "@meitner/feature-y/baz"; // ✅ (other package)
```

It reads each file's nearest `package.json` `name`, so it needs **no per-package configuration** — one rule covers every package. Catches both the bare name and subpaths, on `import` and `export … from`.

## Why

Surfaced in platform: feature packages had ~40 self-imports (a file importing its own package name for a sibling module) that no existing tooling flagged — the configured `no-restricted-imports` only covered `console`/`zod`, and `import/no-self-import` doesn't catch package-name self-refs. This closes that gap generically.

## Tests

`src/tests/noSelfPackageImport.test.ts` — 8 cases including a prefix guard (`@meitner/eslint-plugin-extra` must not match `@meitner/eslint-plugin`). Full suite: 135 passing; `tsc --noEmit` and `eslint` clean.

## Note for consumers (oxlint)

The rule reads `package.json` via `fs` — the first rule in this plugin to touch the filesystem. It's validated under ESLint's RuleTester; consumers running it through **oxlint's jsPlugin runtime** should confirm fs access works there before enabling (it runs in Node, so it should).

🤖 Generated with [Claude Code](https://claude.com/claude-code)